### PR TITLE
TRRA-35: Initial Docker setup - builds base dev image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.7-slim-buster
+
+RUN adduser --system django
+USER django
+
+WORKDIR /home/django
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt --user --no-warn-script-location
+COPY . .
+EXPOSE 8000
+
+RUN [ "python", "./manage.py", "migrate" ]
+RUN [ "python", "./manage.py", "loaddata", "sample_data" ]
+ENTRYPOINT [ "python", "./manage.py", "runserver", "0.0.0.0:8000" ]
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3'
+services:
+  django:
+    build: .
+    ports:
+     - "8000:8000"


### PR DESCRIPTION
Provides an image which can be run for testing the application.
* Python 3.7
* Installs via requirements.txt
* Creates `django` non-root user
* Builds the schema and loads the `sample_data` fixture.
* Exposes port 8000 when run.

Build the image: `docker-compose build`
Run it: `docker run -it -p 8000:8000 terra_django`
Access: http://127.0.0.1:8000/dashboard (login required)

TODO: Add MySQL, probably some smaller refinements
