### PR TITLE
TRRA-35: Add mysql support (image, libraries and initial dev config)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ services:
 before_script:
   - docker-compose up --build -d
   - docker-compose exec django pip install -q coveralls --user --no-warn-script-location
+  - docker-compose top
   - docker-compose exec db mysql -u root -pthis-is-a-fake-password -e "grant all privileges on test_terra.* to 'terrauser'@'%';"
 script:
   - docker-compose exec django /home/django/.local/bin/coverage run --source=terra manage.py test terra

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,12 @@ python:
   - "3.7"
 services:
   - docker
+before_install:
+  - docker-compose up --build -d
 install:
   - pip install -r requirements.txt
   - pip install -q coveralls
-before_script:
-  - docker-compose up --build -d
 script:
   - coverage run --source=terra manage.py test terra
-after_script:
-  - docker-compose down
 after_success:
   coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,11 @@ python:
   - "3.7"
 services:
   - docker
-before_install:
+before_script:
   - docker-compose up --build -d
-install:
-  - pip install -r requirements.txt
-  - pip install -q coveralls
+  - docker-compose exec django pip install -q coveralls --user --no-warn-script-location
+  - docker-compose exec db mysql -u root -pthis-is-a-fake-password -e "grant all privileges on test_terra.* to 'terrauser'@'%';"
 script:
-  - coverage run --source=terra manage.py test terra
+  - docker-compose exec django /home/django/.local/bin/coverage run --source=terra manage.py test terra
 after_success:
   coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,17 @@
 language: python
 dist: xenial
 python:
-  - "3.6"
+  - "3.7"
+services:
+  - docker
 install:
   - pip install -r requirements.txt
   - pip install -q coveralls
+before_script:
+  - docker-compose up --build -d
 script:
   - coverage run --source=terra manage.py test terra
+after_script:
+  - docker-compose down
 after_success:
   coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,7 @@ python:
 services:
   - docker
 before_script:
-  - docker-compose up --build -d
-  - docker-compose exec django pip install -q coveralls --user --no-warn-script-location
-  - docker-compose top
-  - docker-compose exec db mysql -u root -pthis-is-a-fake-password -e "grant all privileges on test_terra.* to 'terrauser'@'%';"
+  - .travis/build_and_test.sh
 script:
   - docker-compose exec django /home/django/.local/bin/coverage run --source=terra manage.py test terra
 after_success:

--- a/.travis/build_and_test.sh
+++ b/.travis/build_and_test.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Try doing it all in one script since Travis is too non-deterministic.....
+
+docker-compose up --build -d
+docker-compose exec django pip install -q coveralls --user --no-warn-script-location
+docker-compose top
+docker-compose exec db mysql -u root -pthis-is-a-fake-password -e "grant all privileges on test_terra.* to 'terrauser'@'%';"
+

--- a/.travis/build_and_test.sh
+++ b/.travis/build_and_test.sh
@@ -3,6 +3,18 @@
 
 docker-compose up --build -d
 docker-compose exec django pip install -q coveralls --user --no-warn-script-location
+
+# Even though the build/up step above waits until the db is available, that's not always the case
+# Keep trying to set db permissions for the django test user, so it can create a clean db for testing.
+until docker-compose exec db mysql -u root -pthis-is-a-fake-password -e "grant all privileges on test_terra.* to 'terrauser'@'%';"; do
+  echo "Waiting for mysql to become available..."
+  sleep 3 
+done
+
+# For testing, to see what's running in the containers at this point
 docker-compose top
-docker-compose exec db mysql -u root -pthis-is-a-fake-password -e "grant all privileges on test_terra.* to 'terrauser'@'%';"
+
+# No longer necessary, since this succeeded in the loop above
+#####docker-compose exec db mysql -u root -pthis-is-a-fake-password -e "grant all privileges on test_terra.* to 'terrauser'@'%';"
+
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
-FROM python:3.7-slim-buster
+FROM python:3.7
 
-RUN apt-get update -qq && apt-get install build-essential python3-dev default-libmysqlclient-dev -y -qq
+RUN apt-get update -qq && apt-get install build-essential python3-dev default-libmysqlclient-dev locales -y -qq
+RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && dpkg-reconfigure --frontend=noninteractive locales
 
 RUN adduser --system django
 USER django

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.7-slim-buster
 
+RUN apt-get update && apt-get install build-essential python3-dev default-libmysqlclient-dev -y
+
 RUN adduser --system django
 USER django
 
@@ -10,7 +12,4 @@ RUN pip install --no-cache-dir -r requirements.txt --user --no-warn-script-locat
 COPY . .
 EXPOSE 8000
 
-RUN [ "python", "./manage.py", "migrate" ]
-RUN [ "python", "./manage.py", "loaddata", "sample_data" ]
-ENTRYPOINT [ "python", "./manage.py", "runserver", "0.0.0.0:8000" ]
-
+CMD [ "sh", "docker/entrypoint.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.7-slim-buster
 
-RUN apt-get update && apt-get install build-essential python3-dev default-libmysqlclient-dev -y
+RUN apt-get update -qq && apt-get install build-essential python3-dev default-libmysqlclient-dev -y -qq
 
 RUN adduser --system django
 USER django

--- a/README.md
+++ b/README.md
@@ -10,29 +10,29 @@ Travel & Entertainment Requests & Reports Application
 1. Install Python 3.6
 	- I recommend following this guide: https://docs.python-guide.org/
 2. Open your terminal and open your projects directory
-		
+
 		$ cd /some/path/where/you/put/code
 
 3. Pull this repo
 	1. with SSH:
-		
+
 			$ git clone git@github.com:UCLALibrary/terra.git
 
 	2. with HTTPS:
-			
+
 			$ git clone https://github.com/UCLALibrary/terra.git
 
 4. Switch to the repo root
-		
+
 		$ cd terra
 
 5. Create a Python virtual environment and activate it
-		
+
 		$ python3 -m venv ENV
 		$ source ENV/bin/activate
 
 6. Update pip and install the Python packages
-		
+
 		$ pip install --upgrade pip
 		$ pip install -r requirements.txt
 
@@ -41,12 +41,28 @@ Travel & Entertainment Requests & Reports Application
 		$ pre-commit install
 
 8. Create the database tables
-		
+
 		$ python manage.py migrate
 
 ### Docker
 
-***TODO***
+1. Install docker and docker-compose.
+
+2. Clone the repo as above.
+
+3. Build: `docker-compose build`
+
+4. Start containers: `docker-compose up -d`
+
+5. Use application: http://127.0.0.1:8000
+  1. If running Docker in a VM, you may need to forward port 8000 from your VM to your native OS.
+
+6. Run commands in the django application container as needed.
+  1. `docker-compose exec django bash` (for a shell), or
+  2. `docker-compose exec python manage.py createsuperuser` (for an ad-hoc command).
+
+7. Stop containers: `docker-compose down`
+
 
 ## Developer Tips
 
@@ -64,7 +80,7 @@ Travel & Entertainment Requests & Reports Application
 
 #### Migrations
 
-When you change the Django models, you need to update the tables in the database by: 
+When you change the Django models, you need to update the tables in the database by:
 
 1. Creating a migration file
 
@@ -79,11 +95,11 @@ When you change the Django models, you need to update the tables in the database
 ### Testing Your Work
 
 1. Use the Django REPL
-		
+
 		$ python manage.py shell
 
 2. Run the development server (at http://localhost:8000)
-		
+
 		$ python manage.py runserver
 
 3. Validate your code

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,3 +4,14 @@ services:
     build: .
     ports:
      - "8000:8000"
+    depends_on:
+      - db
+  db:
+    image: mysql:5.7
+    environment:
+      MYSQL_ROOT_PASSWORD: this-is-a-fake-password
+      MYSQL_DATABASE: terra
+      MYSQL_USER: terrauser
+      MYSQL_PASSWORD: terra-fake-password
+    ports:
+      - "3306:3306"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# Check when database is ready for connections
+until python -c 'import MySQLdb ; db=MySQLdb.connect(host="db",user="terrauser",passwd="terra-fake-password",db="terra")' ; do
+  echo "Database connection not ready - waiting"
+  sleep 5
+done
+
+python ./manage.py migrate
+python ./manage.py loaddata sample_data
+python ./manage.py runserver 0.0.0.0:8000

--- a/proj/settings.py
+++ b/proj/settings.py
@@ -70,9 +70,13 @@ WSGI_APPLICATION = "proj.wsgi.application"
 # https://docs.djangoproject.com/en/2.2/ref/settings/#databases
 
 DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": os.path.join(BASE_DIR, "db.sqlite3"),
+    'default': {
+        'ENGINE': 'django.db.backends.mysql',
+        'NAME': 'terra',
+        'USER': 'terrauser',
+        'PASSWORD': 'terra-fake-password',
+        'HOST': 'db',
+        'PORT': '3306',
     }
 }
 

--- a/proj/settings.py
+++ b/proj/settings.py
@@ -77,6 +77,9 @@ DATABASES = {
         'PASSWORD': 'terra-fake-password',
         'HOST': 'db',
         'PORT': '3306',
+	'TEST': {
+	    'NAME': 'test_terra',
+	},
     }
 }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ Django-crispy-forms
 black
 pre-commit
 fiscalyear
+mysqlclient


### PR DESCRIPTION
This PR *requires* that developers switch to the Docker environment, as it changes `settings.py` to require MySQL instead of sqlite.

Merge this to master only if all developers are ready for this change.