### PR TITLE
Trra 35/webserver config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,18 @@ FROM python:3.7-slim-buster
 RUN apt-get update -qq && apt-get install build-essential python3-dev default-libmysqlclient-dev locales -y -qq
 RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && dpkg-reconfigure --frontend=noninteractive locales
 
-RUN adduser --system django
+RUN useradd -c "django app user" -d /home/django -s /bin/bash -m django
 USER django
+
+ENV PATH /home/django/.local/bin:${PATH}
+ENV GUNICORN_CMD_ARGS -w 3 -b 0.0.0.0:8000
 
 WORKDIR /home/django
 
-COPY requirements.txt .
+COPY --chown=django:django . .
+
 RUN pip install --no-cache-dir -r requirements.txt --user --no-warn-script-location
-COPY . .
+
 EXPOSE 8000
 
 CMD [ "sh", "docker/entrypoint.sh" ]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -6,6 +6,12 @@ until python -c 'import MySQLdb ; db=MySQLdb.connect(host="db",user="terrauser",
   sleep 5
 done
 
+# Run database migrations
 python ./manage.py migrate
 python ./manage.py loaddata sample_data
-python ./manage.py runserver 0.0.0.0:8000
+
+# Build static files directory
+python ./manage.py collectstatic
+
+# Start the Gunicorn web server
+gunicorn proj.wsgi:application

--- a/proj/settings.py
+++ b/proj/settings.py
@@ -37,6 +37,7 @@ CRISPY_TEMPLATE_PACK = "bootstrap4"
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
+    "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
@@ -115,6 +116,8 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/2.2/howto/static-files/
 
 STATIC_URL = "/static/"
-STATIC_ROOT = os.path.join(BASE_DIR, "/static/")
+STATIC_ROOT = os.path.join(BASE_DIR, "static")
+
+STATICFILES_STORAGE = 'whitenoise.storage.CompressedStaticFilesStorage'
 
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ black
 pre-commit
 fiscalyear
 mysqlclient
+whitenoise
+gunicorn


### PR DESCRIPTION
@akohler Can you please review when you get a chance? These are my changes to enable the Terra python app to be served via a `gunicorn` server and static files to be served via the `whilenoise` module. 