### PR TITLE
TRRA-83: Mounts code in the django container, allowing more efficient dev cycle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ lib/
 lib64/
 parts/
 sdist/
+# Ignore only top-level static directory created on run-time
+/static/
 var/
 wheels/
 *.egg-info/

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,7 @@ python:
   - "3.7"
 services:
   - docker
-before_script:
-  - .travis/build_and_test.sh
 script:
-  - docker-compose exec django /home/django/.local/bin/coverage run --source=terra manage.py test terra
+  - .travis/build_and_test.sh
 after_success:
   coveralls

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ENV PATH /home/django/.local/bin:${PATH}
 # --access-logfile where to send HTTP access logs (- is stdout)
 ENV GUNICORN_CMD_ARGS -w 3 -b 0.0.0.0:8000 --access-logfile -
 
-WORKDIR /home/django
+WORKDIR /home/django/terra
 
 COPY --chown=django:django requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt --user --no-warn-script-location

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@ version: '3'
 services:
   django:
     build: .
+    volumes:
+      - .:/home/django/terra
     env_file:
       - .docker-compose_django.env
     ports:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -10,8 +10,8 @@ done
 python ./manage.py migrate
 python ./manage.py loaddata sample_data
 
-# Build static files directory
-python ./manage.py collectstatic
+# Build static files directory, starting fresh each time
+python ./manage.py collectstatic --clear --no-input
 
 # Start the Gunicorn web server
 gunicorn proj.wsgi:application

--- a/proj/settings.py
+++ b/proj/settings.py
@@ -23,6 +23,8 @@ ALLOWED_HOSTS = []
 # Application definition
 
 INSTALLED_APPS = [
+    # Enable whitenoise in development per http://whitenoise.evans.io/en/stable/django.html
+    "whitenoise.runserver_nostatic",
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",


### PR DESCRIPTION
This PR also moves the code to a subdirectory of `/home/django`, and improves the static file handling done by django / whitenoise.