### PR TITLE
Django service pulls terra image from Docker Hub instead of building

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   django:
-    build: .
+    image: uclalibrary/terra:latest
     volumes:
       - .:/home/django/terra
     env_file:


### PR DESCRIPTION
The main `docker-compose.yml` file used for development no longer builds the terra image. It will pull the image with the `latest` tag and use that for running the container. 