### PR TITLE
Switch from MySQL 8.0 to 5.7 in db service

### DIFF
--- a/.travis/docker-compose_travis_test.yml
+++ b/.travis/docker-compose_travis_test.yml
@@ -12,7 +12,7 @@ services:
     depends_on:
       - db
   db:
-    image: mysql:8.0
+    image: mysql:5.7
     command: --default-authentication-plugin=mysql_native_password
     env_file:
       - ../.docker-compose_db.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     depends_on:
       - db
   db:
-    image: mysql:8.0
+    image: mysql:5.7
     command: --default-authentication-plugin=mysql_native_password
     env_file:
       - .docker-compose_db.env


### PR DESCRIPTION
With updates to the queries merged in with PR #30 we no longer require the use of MySQL 8.0 in the docker-compose files. This PR changes the configuration back to use the MySQL 5.7 image. 