### PR TITLE
Create the terra subdir and set ownership before it is set as the workdir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,9 @@ ENV PATH /home/django/.local/bin:${PATH}
 # --access-logfile where to send HTTP access logs (- is stdout)
 ENV GUNICORN_CMD_ARGS -w 3 -b 0.0.0.0:8000 --access-logfile -
 
-RUN mkdir /home/django/terra && chown django:django terra
+WORKDIR /home/django
+
+RUN mkdir terra && chown django:django terra
 
 WORKDIR /home/django/terra
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ ENV GUNICORN_CMD_ARGS -w 3 -b 0.0.0.0:8000 --access-logfile -
 
 WORKDIR /home/django/terra
 
+RUN chown django:django /home/django/terra
+
 COPY --chown=django:django requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt --user --no-warn-script-location
 COPY --chown=django:django . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,9 @@ ENV PATH /home/django/.local/bin:${PATH}
 # --access-logfile where to send HTTP access logs (- is stdout)
 ENV GUNICORN_CMD_ARGS -w 3 -b 0.0.0.0:8000 --access-logfile -
 
-WORKDIR /home/django/terra
+RUN mkdir /home/django/terra && chown django:django terra
 
-RUN chown django:django /home/django/terra
+WORKDIR /home/django/terra
 
 COPY --chown=django:django requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt --user --no-warn-script-location


### PR DESCRIPTION
I encountered permissions problems when trying to run the terra container within the docker swarm cluster. The error pertains to being able to create the `/home/django/terra/static` directory. 

After some investigation, I discovered that when the bind mount is used for this directory, the permission errors go away. When I'm **not** using the bind mount, and we're trying to create the static file dir at run time from within the container, it seems this is where the permissions issue arise.

The changes made to the Dockerfile I'm hoping will ensure the terra sub-directory is created ahead of time and has the appropriate ownership before we use it as the workdir. 