### PR TITLE
Restore Dockerfile to previous state and include static dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,8 +18,6 @@ lib/
 lib64/
 parts/
 sdist/
-# Ignore only top-level static directory created on run-time
-/static/
 var/
 wheels/
 *.egg-info/

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,10 +15,6 @@ ENV PATH /home/django/.local/bin:${PATH}
 # --access-logfile where to send HTTP access logs (- is stdout)
 ENV GUNICORN_CMD_ARGS -w 3 -b 0.0.0.0:8000 --access-logfile -
 
-WORKDIR /home/django
-
-RUN mkdir terra && chown django:django terra
-
 WORKDIR /home/django/terra
 
 COPY --chown=django:django requirements.txt .

--- a/static/.gitignore
+++ b/static/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
As a way to get around the permissions problem with creating the static subdir during container start-up, I'm going to have the static dir already exist in the repo. I realize we don't want any files that may get created in the static directory to be checked-in to the repo. So I added a .gitingore inside the static dir to prevent that from happening. 