### PR TITLE
Allowed hosts list and prevent clearing of static files dir at start-up

### DIFF
--- a/.docker-compose_django.env
+++ b/.docker-compose_django.env
@@ -12,7 +12,8 @@ DJANGO_RUN_ENV=dev
 
 DJANGO_DEBUG=True
 
-DJANGO_ALLOWED_HOSTS=[]
+# Comma separated list of allowed hosts
+DJANGO_ALLOWED_HOSTS=localhost,127.0.0.1,[::1]
 
 DJANGO_DB_ENGINE=django.db.backends.mysql
 DJANGO_DB_NAME=terra

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -16,7 +16,7 @@ if [ "$DJANGO_RUN_ENV" = "dev" ]; then
 fi
 
 # Build static files directory, starting fresh each time
-python ./manage.py collectstatic --clear --no-input
+python ./manage.py collectstatic --no-input
 
 # Start the Gunicorn web server
 gunicorn proj.wsgi:application

--- a/proj/settings.py
+++ b/proj/settings.py
@@ -17,7 +17,11 @@ SECRET_KEY = os.getenv('DJANGO_SECRET_KEY')
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.getenv('DJANGO_DEBUG')
 
-ALLOWED_HOSTS = [os.getenv('DJANGO_ALLOWED_HOSTS')]
+# Define the list of allowed hosts to connect to this application
+# This is passed in via the environment variable DJANGO_ALLOWED_HOSTS
+# which is a string - but ALLOWED_HOSTS requires a list
+
+ALLOWED_HOSTS = list(os.getenv('DJANGO_ALLOWED_HOSTS').split(","))
 
 # Application definition
 


### PR DESCRIPTION
This PR removes the `--clear` from the `collectstatic` start-up routine to ensure the static file directory persists along with the .gitignore inside.

Also I put in place a fix to create the list of allowed hosts in settings.py. The env var `DJANGO_ALLOWED_HOSTS` returns a string, but the parameter in settings.py expects a list. 

I created a default list that includes `[localhost, 127.0.0.1, [::1]]`