### PR TITLE
TRRA-84: Allows tests to be run locally without workarounds

### DIFF
--- a/.travis/build_and_test.sh
+++ b/.travis/build_and_test.sh
@@ -12,10 +12,12 @@ ${DOCKER_COMPOSE_TRAVIS} exec django pip install -q coveralls --user --no-warn-s
 
 # Even though the build/up step above waits until the db is available, that's not always the case
 # Keep trying to set db permissions for the django test user, so it can create a clean db for testing.
-until ${DOCKER_COMPOSE_TRAVIS} exec db mysql -u root -pthis-is-a-fake-password -e "grant all privileges on test_terra.* to 'terrauser'@'%';"; do
-  echo "Waiting for mysql to become available..."
-  sleep 3
-done
+# Is this still necessary?  Let's just try a sleep.
+#until ${DOCKER_COMPOSE_TRAVIS} exec db mysql -u root -pthis-is-a-fake-password -e "grant all privileges on test_terra.* to 'terrauser'@'%';"; do
+#  echo "Waiting for mysql to become available..."
+#  sleep 3
+#done
+sleep 10
 
 # When building in Travis, the host directory is owned by Travis.  The volume mount in the django Docker
 # container apparently reflects that, leading to permissions problems inside the container when running tests.

--- a/.travis/docker-compose_travis_test.yml
+++ b/.travis/docker-compose_travis_test.yml
@@ -7,6 +7,7 @@ services:
       - ..:/home/django/terra
     env_file:
       - ../.docker-compose_django.env
+      - ../.docker-compose_db.env
     ports:
      - "8000:8000"
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       - .:/home/django/terra
     env_file:
       - .docker-compose_django.env
+      - .docker-compose_db.env
     ports:
      - "8000:8000"
     depends_on:

--- a/proj/settings.py
+++ b/proj/settings.py
@@ -83,9 +83,9 @@ DATABASES = {
         'PASSWORD': os.getenv('DJANGO_DB_PASSWD'),
         'HOST': os.getenv('DJANGO_DB_HOST'),
         'PORT': os.getenv('DJANGO_DB_PORT'),
-	'TEST': {
-	    'NAME': os.getenv('DJANGO_TEST_DB_NAME'),
-	},
+    	'TEST': {
+    	    'NAME': os.getenv('DJANGO_TEST_DB_NAME'),
+    	},
     }
 }
 

--- a/terra/management/commands/test.py
+++ b/terra/management/commands/test.py
@@ -1,0 +1,28 @@
+from django.core.management.base import BaseCommand, CommandError
+from django.core.management.commands import test
+
+import os
+import MySQLdb
+
+class Command(test.Command):
+    help = "Overrides built-in test command to set MySQL permissions on test database."
+
+    def handle(self, *args, **options):
+        # Django does not give the MySQL db user rights to create a test db.
+        # Send appropriate database command to db server, but only in DEV.
+        if os.getenv("DJANGO_RUN_ENV") == "dev":
+            host = os.getenv("DJANGO_DB_HOST")
+            passwd = os.getenv("MYSQL_ROOT_PASSWORD")
+            prod_db = os.getenv("DJANGO_DB_NAME")
+            test_db = os.getenv("DJANGO_TEST_DB_NAME")
+            db_user = os.getenv("DJANGO_DB_USER")
+
+            # Have to specify a db; prod exists, test doesn't
+            con = MySQLdb.connect(host=host, user="root", passwd=passwd, db=prod_db)
+            cur = con.cursor()
+            sql = f"grant all privileges on {test_db}.* to '{db_user}'@'%';"
+            cur.execute(sql)
+            cur.close()
+            con.close()
+
+        super(Command, self).handle(*args, **options)


### PR DESCRIPTION
This PR overrides django's built-in 'test` command by updating mysql permissions so that the transient test database can be created.  The developer no longer needs to work around this by running a mysql command before running tests.

Some minor tweaks to the dev- and Travis-specific builds were necessary to support this, by making mysql environment variables available to the django container.  This won't be necessary in our server builds.

@sgurnick or @joshuago78 : Please review.