### PR TITLE
TRRA-101: Allow developers to see code changes immediately

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,8 @@ ENV PATH /home/django/.local/bin:${PATH}
 # Gunicorn cmd line flags:
 # -w number of gunicorn worker processes
 # -b IPADDR:PORT binding
-# --reload pick up code changes as they happen
 # --access-logfile where to send HTTP access logs (- is stdout)
-ENV GUNICORN_CMD_ARGS -w 3 -b 0.0.0.0:8000 --reload --access-logfile -
+ENV GUNICORN_CMD_ARGS -w 3 -b 0.0.0.0:8000 --access-logfile -
 
 WORKDIR /home/django/terra
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,9 @@ ENV PATH /home/django/.local/bin:${PATH}
 # Gunicorn cmd line flags:
 # -w number of gunicorn worker processes
 # -b IPADDR:PORT binding
+# --reload pick up code changes as they happen
 # --access-logfile where to send HTTP access logs (- is stdout)
-ENV GUNICORN_CMD_ARGS -w 3 -b 0.0.0.0:8000 --access-logfile -
+ENV GUNICORN_CMD_ARGS -w 3 -b 0.0.0.0:8000 --reload --access-logfile -
 
 WORKDIR /home/django/terra
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -18,5 +18,9 @@ fi
 # Build static files directory, starting fresh each time
 python ./manage.py collectstatic --no-input
 
-# Start the Gunicorn web server
-gunicorn proj.wsgi:application
+if [ "$DJANGO_RUN_ENV" = "dev" ]; then
+  python ./manage.py runserver 0.0.0.0:8000
+else
+  # Start the Gunicorn web server
+  gunicorn proj.wsgi:application
+fi


### PR DESCRIPTION
This PR uses the built-in `runserver` instead of `gunicorn`, in the DEV environment.  This allows developers to see their changes immediately in the browser.

It also adds the `--reload` flag to `gunicorn`, which helped a little, but not enough, thus the switch back to `runserver`.

There may be better ways to do this, but it addresses a major need for developers now, who otherwise have to do a `docker-compose down && docker-compose up -d` after every code change in order to see changes in the browser.

@sgurnick or @joshuago78 , please review and if OK for now, merge. Thanks.