### PR TITLE
TRRA-111: Give members of LBS Staff group full report access

### DIFF
--- a/terra/fixtures/sample_data.json
+++ b/terra/fixtures/sample_data.json
@@ -1,5 +1,594 @@
 [
 {
+  "model": "auth.permission",
+  "pk": 1,
+  "fields": {
+    "name": "Can add log entry",
+    "content_type": 1,
+    "codename": "add_logentry"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 2,
+  "fields": {
+    "name": "Can change log entry",
+    "content_type": 1,
+    "codename": "change_logentry"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 3,
+  "fields": {
+    "name": "Can delete log entry",
+    "content_type": 1,
+    "codename": "delete_logentry"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 4,
+  "fields": {
+    "name": "Can view log entry",
+    "content_type": 1,
+    "codename": "view_logentry"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 5,
+  "fields": {
+    "name": "Can add permission",
+    "content_type": 2,
+    "codename": "add_permission"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 6,
+  "fields": {
+    "name": "Can change permission",
+    "content_type": 2,
+    "codename": "change_permission"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 7,
+  "fields": {
+    "name": "Can delete permission",
+    "content_type": 2,
+    "codename": "delete_permission"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 8,
+  "fields": {
+    "name": "Can view permission",
+    "content_type": 2,
+    "codename": "view_permission"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 9,
+  "fields": {
+    "name": "Can add group",
+    "content_type": 3,
+    "codename": "add_group"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 10,
+  "fields": {
+    "name": "Can change group",
+    "content_type": 3,
+    "codename": "change_group"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 11,
+  "fields": {
+    "name": "Can delete group",
+    "content_type": 3,
+    "codename": "delete_group"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 12,
+  "fields": {
+    "name": "Can view group",
+    "content_type": 3,
+    "codename": "view_group"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 13,
+  "fields": {
+    "name": "Can add user",
+    "content_type": 4,
+    "codename": "add_user"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 14,
+  "fields": {
+    "name": "Can change user",
+    "content_type": 4,
+    "codename": "change_user"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 15,
+  "fields": {
+    "name": "Can delete user",
+    "content_type": 4,
+    "codename": "delete_user"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 16,
+  "fields": {
+    "name": "Can view user",
+    "content_type": 4,
+    "codename": "view_user"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 17,
+  "fields": {
+    "name": "Can add content type",
+    "content_type": 5,
+    "codename": "add_contenttype"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 18,
+  "fields": {
+    "name": "Can change content type",
+    "content_type": 5,
+    "codename": "change_contenttype"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 19,
+  "fields": {
+    "name": "Can delete content type",
+    "content_type": 5,
+    "codename": "delete_contenttype"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 20,
+  "fields": {
+    "name": "Can view content type",
+    "content_type": 5,
+    "codename": "view_contenttype"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 21,
+  "fields": {
+    "name": "Can add session",
+    "content_type": 6,
+    "codename": "add_session"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 22,
+  "fields": {
+    "name": "Can change session",
+    "content_type": 6,
+    "codename": "change_session"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 23,
+  "fields": {
+    "name": "Can delete session",
+    "content_type": 6,
+    "codename": "delete_session"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 24,
+  "fields": {
+    "name": "Can view session",
+    "content_type": 6,
+    "codename": "view_session"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 25,
+  "fields": {
+    "name": "Can add activity",
+    "content_type": 7,
+    "codename": "add_activity"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 26,
+  "fields": {
+    "name": "Can change activity",
+    "content_type": 7,
+    "codename": "change_activity"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 27,
+  "fields": {
+    "name": "Can delete activity",
+    "content_type": 7,
+    "codename": "delete_activity"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 28,
+  "fields": {
+    "name": "Can view activity",
+    "content_type": 7,
+    "codename": "view_activity"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 29,
+  "fields": {
+    "name": "Can add approval",
+    "content_type": 8,
+    "codename": "add_approval"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 30,
+  "fields": {
+    "name": "Can change approval",
+    "content_type": 8,
+    "codename": "change_approval"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 31,
+  "fields": {
+    "name": "Can delete approval",
+    "content_type": 8,
+    "codename": "delete_approval"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 32,
+  "fields": {
+    "name": "Can view approval",
+    "content_type": 8,
+    "codename": "view_approval"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 33,
+  "fields": {
+    "name": "Can add employee",
+    "content_type": 9,
+    "codename": "add_employee"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 34,
+  "fields": {
+    "name": "Can change employee",
+    "content_type": 9,
+    "codename": "change_employee"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 35,
+  "fields": {
+    "name": "Can delete employee",
+    "content_type": 9,
+    "codename": "delete_employee"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 36,
+  "fields": {
+    "name": "Can view employee",
+    "content_type": 9,
+    "codename": "view_employee"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 37,
+  "fields": {
+    "name": "Can add fund",
+    "content_type": 10,
+    "codename": "add_fund"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 38,
+  "fields": {
+    "name": "Can change fund",
+    "content_type": 10,
+    "codename": "change_fund"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 39,
+  "fields": {
+    "name": "Can delete fund",
+    "content_type": 10,
+    "codename": "delete_fund"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 40,
+  "fields": {
+    "name": "Can view fund",
+    "content_type": 10,
+    "codename": "view_fund"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 41,
+  "fields": {
+    "name": "Can add travel request",
+    "content_type": 11,
+    "codename": "add_travelrequest"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 42,
+  "fields": {
+    "name": "Can change travel request",
+    "content_type": 11,
+    "codename": "change_travelrequest"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 43,
+  "fields": {
+    "name": "Can delete travel request",
+    "content_type": 11,
+    "codename": "delete_travelrequest"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 44,
+  "fields": {
+    "name": "Can view travel request",
+    "content_type": 11,
+    "codename": "view_travelrequest"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 45,
+  "fields": {
+    "name": "Can add vacation",
+    "content_type": 12,
+    "codename": "add_vacation"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 46,
+  "fields": {
+    "name": "Can change vacation",
+    "content_type": 12,
+    "codename": "change_vacation"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 47,
+  "fields": {
+    "name": "Can delete vacation",
+    "content_type": 12,
+    "codename": "delete_vacation"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 48,
+  "fields": {
+    "name": "Can view vacation",
+    "content_type": 12,
+    "codename": "view_vacation"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 49,
+  "fields": {
+    "name": "Can add unit",
+    "content_type": 13,
+    "codename": "add_unit"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 50,
+  "fields": {
+    "name": "Can change unit",
+    "content_type": 13,
+    "codename": "change_unit"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 51,
+  "fields": {
+    "name": "Can delete unit",
+    "content_type": 13,
+    "codename": "delete_unit"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 52,
+  "fields": {
+    "name": "Can view unit",
+    "content_type": 13,
+    "codename": "view_unit"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 53,
+  "fields": {
+    "name": "Can add estimated expense",
+    "content_type": 14,
+    "codename": "add_estimatedexpense"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 54,
+  "fields": {
+    "name": "Can change estimated expense",
+    "content_type": 14,
+    "codename": "change_estimatedexpense"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 55,
+  "fields": {
+    "name": "Can delete estimated expense",
+    "content_type": 14,
+    "codename": "delete_estimatedexpense"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 56,
+  "fields": {
+    "name": "Can view estimated expense",
+    "content_type": 14,
+    "codename": "view_estimatedexpense"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 57,
+  "fields": {
+    "name": "Can add actual expense",
+    "content_type": 15,
+    "codename": "add_actualexpense"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 58,
+  "fields": {
+    "name": "Can change actual expense",
+    "content_type": 15,
+    "codename": "change_actualexpense"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 59,
+  "fields": {
+    "name": "Can delete actual expense",
+    "content_type": 15,
+    "codename": "delete_actualexpense"
+  }
+},
+{
+  "model": "auth.permission",
+  "pk": 60,
+  "fields": {
+    "name": "Can view actual expense",
+    "content_type": 15,
+    "codename": "view_actualexpense"
+  }
+},
+{
+  "model": "auth.group",
+  "pk": 1,
+  "fields": {
+    "name": "LBS Staff",
+    "permissions": [
+      13,
+      14,
+      15,
+      16,
+      45,
+      46,
+      47,
+      48,
+      57,
+      58,
+      59,
+      60,
+      49,
+      50,
+      51,
+      52,
+      29,
+      30,
+      31,
+      32,
+      53,
+      54,
+      55,
+      56,
+      33,
+      34,
+      35,
+      36,
+      37,
+      38,
+      39,
+      40,
+      25,
+      26,
+      27,
+      28,
+      41,
+      42,
+      43,
+      44
+    ]
+  }
+},
+{
   "model": "auth.user",
   "pk": 1,
   "fields": {
@@ -95,7 +684,7 @@
   "fields": {
     "password": "pbkdf2_sha256$150000$1KegWw2vRLcR$LOOI86ivTpeWXwWOV2omAm4BSAOEaJZFjupK2ChGuhw=",
     "last_login": "2019-09-06T20:55:57.899Z",
-    "is_superuser": true,
+    "is_superuser": false,
     "username": "doriswang",
     "first_name": "Doris",
     "last_name": "Wang",
@@ -103,7 +692,7 @@
     "is_staff": true,
     "is_active": true,
     "date_joined": "2019-08-13T22:59:03Z",
-    "groups": [],
+    "groups": [1],
     "user_permissions": []
   }
 },

--- a/terra/models.py
+++ b/terra/models.py
@@ -94,6 +94,13 @@ class Employee(models.Model):
     def name(self):
         return str(self)
 
+    def has_full_report_access(self):
+        # Superusers and members of LBS Staff have full access to reports.
+        return (
+            self.user.is_superuser
+            or self.user.groups.filter(name='LBS Staff').exists()
+        )
+
     def is_unit_manager(self):
         return self.managed_units.count() > 0
 

--- a/terra/templates/terra/base.html
+++ b/terra/templates/terra/base.html
@@ -40,12 +40,12 @@
           <li class="nav-item">
             <a class="nav-link" href="/dashboard/">Dashboard</a>
           </li>
-          {% if request.user.employee.is_unit_manager or request.user.is_superuser %}
+          {% if request.user.employee.is_unit_manager or request.user.employee.has_full_report_access %}
           <li class="nav-item">
             <a class="nav-link" href="/unit/">Unit Reports</a>
           </li>
           {% endif %}
-          {% if request.user.employee.is_fund_manager or request.user.is_superuser %}
+          {% if request.user.employee.is_fund_manager or request.user.employee.has_full_report_access %}
           <li class="nav-item">
             <a class="nav-link" href="/fund/">FAU Reports</a>
           </li>

--- a/terra/tests.py
+++ b/terra/tests.py
@@ -71,6 +71,14 @@ class ModelsTestCase(TestCase):
         self.assertTrue(emp.is_unit_manager())
         self.assertTrue(emp.is_fund_manager())
 
+    def test_employee_has_full_report_access(self):
+        emp = Employee.objects.get(user=User.objects.get(username='doriswang'))
+        self.assertTrue(emp.has_full_report_access())
+        emp = Employee.objects.get(user=User.objects.get(username='aprigge'))
+        self.assertFalse(emp.has_full_report_access())
+        emp.user.groups.add(1)
+        self.assertTrue(emp.has_full_report_access())
+
     def test_fund(self):
         fund = Fund.objects.get(pk=1)
         self.assertEqual(str(fund), "605000-LD-19900")
@@ -250,7 +258,7 @@ class TestUnitDetailView(TestCase):
         response = self.client.get("/unit/3/")
         self.assertEqual(response.status_code, 200)
 
-    def test_unit_detail_allows_superuser(self):
+    def test_unit_detail_allows_full_access(self):
         self.client.login(username="doriswang", password="Staples50141")
         response = self.client.get("/unit/1/")
         self.assertTemplateUsed(response, "terra/unit.html")
@@ -271,7 +279,7 @@ class TestUnitListView(TestCase):
         response = self.client.get("/unit/", follow=True)
         self.assertRedirects(response, "/accounts/login/?next=/unit/", status_code=302)
 
-    def test_unit_detail_allows_superuser(self):
+    def test_unit_detail_allows_full_access(self):
         self.client.login(username="doriswang", password="Staples50141")
         response = self.client.get("/unit/")
         self.assertEqual(response.status_code, 200)
@@ -542,7 +550,7 @@ class TestFundDetailView(TestCase):
             response, "/accounts/login/?next=/fund/1/", status_code=302
         )
 
-    def test_fund_detail_allows_superuser(self):
+    def test_fund_detail_allows_full_access(self):
         self.client.login(username="doriswang", password="Staples50141")
         response = self.client.get("/fund/1/")
         self.assertEqual(response.status_code, 200)
@@ -563,7 +571,7 @@ class TestFundListView(TestCase):
         response = self.client.get("/fund/", follow=True)
         self.assertRedirects(response, "/accounts/login/?next=/fund/", status_code=302)
 
-    def test_fund_detail_allows_superuser(self):
+    def test_fund_detail_allows_full_access(self):
         self.client.login(username="doriswang", password="Staples50141")
         response = self.client.get("/fund/")
         self.assertEqual(response.status_code, 200)

--- a/terra/views.py
+++ b/terra/views.py
@@ -27,7 +27,7 @@ class UnitDetailView(LoginRequiredMixin, UserPassesTestMixin, DetailView):
     redirect_field_name = "next"
 
     def test_func(self):
-        if self.request.user.is_superuser:
+        if self.request.user.employee.has_full_report_access():
             return True
         unit = self.get_object()
         return self.request.user.employee in unit.super_managers()
@@ -53,12 +53,12 @@ class UnitListView(LoginRequiredMixin, UserPassesTestMixin, ListView):
 
     def test_func(self):
         return (
-            self.request.user.is_superuser
+            self.request.user.employee.has_full_report_access()
             or self.request.user.employee.is_unit_manager()
         )
 
     def get_queryset(self):
-        if self.request.user.is_superuser:
+        if self.request.user.employee.has_full_report_access():
             return Unit.objects.filter(type="1")
         return Unit.objects.filter(manager=self.request.user.employee)
 
@@ -71,7 +71,7 @@ class FundDetailView(LoginRequiredMixin, UserPassesTestMixin, DetailView):
     redirect_field_name = "next"
 
     def test_func(self):
-        if self.request.user.is_superuser:
+        if self.request.user.employee.has_full_report_access():
             return True
         fund = self.get_object()
         return self.request.user.employee in fund.super_managers()
@@ -97,11 +97,11 @@ class FundListView(LoginRequiredMixin, UserPassesTestMixin, ListView):
 
     def test_func(self):
         return (
-            self.request.user.is_superuser
+            self.request.user.employee.has_full_report_access()
             or self.request.user.employee.is_fund_manager()
         )
 
     def get_queryset(self):
-        if self.request.user.is_superuser:
+        if self.request.user.employee.has_full_report_access():
             return Fund.objects.all()
         return Fund.objects.filter(manager=self.request.user.employee)


### PR DESCRIPTION
Members of the `LBS Staff` group should have full access to all reports, but are not superusers.  This PR:
* Adds a `has_full_report_access()` function to `Employee`
* Replaces direct references to `is_superuser` with the new function in views, tests and templates
* Adds the new group to `sample_data.json`, for developers
* Updates the sample Doris account to remove superuser permission and make her a member of the group
* Adds tests verifying the group membership is correctly used

@joshuago78 Please review.
