### PR TITLE
TRRA-79: Add search boxes to all models, and remove most filters

### DIFF
--- a/terra/admin.py
+++ b/terra/admin.py
@@ -27,13 +27,15 @@ class ApprovalInline(admin.TabularInline):
 @admin.register(Unit)
 class UnitAdmin(admin.ModelAdmin):
     list_display = ("name", "manager", "employee_count", "parent_unit")
-    list_filter = ("name","manager",("parent_unit", custom_titled_filter('parent unit')),)
+    list_filter = (("parent_unit", custom_titled_filter('parent unit')),)
+    search_fields = ["name"]
 
 @admin.register(Employee)
 class EmployeeAdmin(admin.ModelAdmin):
     list_display = ("uid", "name", "unit", "supervisor", "active")
     list_display_links = ("uid", "name")
-    list_filter = ("user","unit","active","uid","supervisor",)
+    list_filter = ("active",)
+    search_fields = ["user__last_name", "user__first_name", "unit__name"]
 
 @admin.register(TravelRequest)
 class TravelRequestAdmin(admin.ModelAdmin):
@@ -50,36 +52,42 @@ class TravelRequestAdmin(admin.ModelAdmin):
         "allocations_total",
         "expenditures_total",
     )
-    list_filter = ("traveler","activity",("departure_date", custom_titled_filter('departure date')),("return_date", custom_titled_filter('return date')),("days_ooo", custom_titled_filter('days out-of-office')),"closed","funds",)
+    list_filter = (("departure_date", custom_titled_filter('departure date')),("return_date", custom_titled_filter('return date')),("days_ooo", custom_titled_filter('days out-of-office')),"closed","funds",)
+    search_fields = ["traveler__user__last_name", "traveler__user__first_name", "activity__name"]
     inlines = (ApprovalInline,)
 
 @admin.register(Activity)
 class ActivityAdmin(admin.ModelAdmin):
     list_display = ("name", "start", "end", "city", "state", "country")
-    list_filter = ("name",("start", custom_titled_filter('start date')),("end", custom_titled_filter('end date')),"city","state","country",)
+    list_filter = (("start", custom_titled_filter('start date')),("end", custom_titled_filter('end date')),"city","state","country",)
+    search_fields = ["name", "city", "state", "country"]
 
 @admin.register(Vacation)
 class VacationAdmin(admin.ModelAdmin):
     list_display = ("id", "treq", "start", "end")
-    list_filter = ("treq__traveler",("treq__activity__name", custom_titled_filter('activity')),("start", custom_titled_filter('start date')),("end", custom_titled_filter('end date')),)
+    list_filter = (("start", custom_titled_filter('start date')),("end", custom_titled_filter('end date')),)
+    search_fields = ["treq__traveler__user__last_name", "treq__traveler__user__first_name", "treq__activity__name"]
 
 @admin.register(Fund)
 class FundAdmin(admin.ModelAdmin):
     list_display = ("__str__", "manager")
-    list_filter = ("account",("cost_center", custom_titled_filter('cost center')),"fund","manager",)
+    search_fields = ["account", "cost_center", "fund", "manager__user__last_name", "manager__user__first_name"]
 
 @admin.register(Approval)
 class ApprovalAdmin(admin.ModelAdmin):
     list_display = ("id", "treq", "approved_by", "approved_on", "fund", "amount")
-    list_filter = (("approved_on", custom_titled_filter('approval date')),"approved_by","treq__traveler",("treq__activity__name", custom_titled_filter('activity')),)
+    list_filter = (("approved_on", custom_titled_filter('approval date')),)
+    search_fields = ["treq__traveler__user__last_name", "treq__traveler__user__first_name", "treq__activity__name"]
 
 @admin.register(EstimatedExpense)
 class EstimatedExpenseAdmin(admin.ModelAdmin):
     list_display = ("id", "treq", "type", "total_dollars")
-    list_filter = ("treq__traveler",("treq__activity__name", custom_titled_filter('activity')),"type",("total", custom_titled_filter('total cost')),)
+    list_filter = ("type",("total", custom_titled_filter('total cost')),)
+    search_fields = ["treq__traveler__user__last_name", "treq__traveler__user__first_name", "treq__activity__name"]
 
 @admin.register(ActualExpense)
 class ActualExpenseAdmin(admin.ModelAdmin):
     list_display = ("id", "treq", "type", "total_dollars")
-    list_filter = ("treq__traveler",("treq__activity__name", custom_titled_filter('activity')),"type",("total", custom_titled_filter('total cost')),"fund",)
+    list_filter = ("type",("total", custom_titled_filter('total cost')),)
+    search_fields = ["treq__traveler__user__last_name", "treq__traveler__user__first_name", "treq__activity__name"]
  


### PR DESCRIPTION
This PR:
* Adds keyword search boxes to all models, using appropriate fields like employee names, activity names, fund parts, unit names, etc.
* Removes long lists of filters from most models, generally leaving only dates and short lists.

I did not use the existing work @DRickard did on branch TRRA-79.
There's no auto-complete here.  That's better done on the admin add/edit screens. See notes on the Jira issue TRRA-79 for more context.

@joshuago78 or @DRickard Please review.