### PR TITLE
TRRA-130: Loads local requirements.txt in dev environment when container starts

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# Pick up any local changes to requirements.txt, which do *not* automatically get re-installed when starting the container.
+# Do this only in dev environment!
+if [ "$DJANGO_RUN_ENV" = "dev" ]; then
+  pip install --no-cache-dir -r requirements.txt --user --no-warn-script-location
+fi
+
 # Check when database is ready for connections
 until python -c 'import os ; import MySQLdb ; db=MySQLdb.connect(host=os.environ.get("DJANGO_DB_HOST"),user=os.environ.get("DJANGO_DB_USER"),passwd=os.environ.get("DJANGO_DB_PASSWD"),db=os.environ.get("DJANGO_DB_NAME"))' ; do
   echo "Database connection not ready - waiting"


### PR DESCRIPTION
This fixes a problem where Docker does not pick up local changes to `requirements.txt`.  Rebuilding the image locally with `docker-compose up --build` doesn't help, it just uses (or re-pulls) the image from Docker Hub.

This changes the Docker entrypoint script so that, in the dev environment only, a fresh `pip install` is done using the local `requirements.txt`.  Most modules will already be present; this picks up anything new.