### PR TITLE
TRRA-135: Configuration to support email backend and smtp relay host

### DIFF
--- a/.docker-compose_django.env
+++ b/.docker-compose_django.env
@@ -22,3 +22,4 @@ DJANGO_DB_PASSWD=terra-fake-password
 DJANGO_DB_HOST=db
 DJANGO_DB_PORT=3306
 DJANGO_TEST_DB_NAME=test_terra
+DJANGO_EMAIL_BACKEND=django.core.mail.backends.console.EmailBackend

--- a/proj/settings.py
+++ b/proj/settings.py
@@ -131,4 +131,7 @@ if not os.path.isdir(STATIC_ROOT):
 
 STATICFILES_STORAGE = 'whitenoise.storage.CompressedStaticFilesStorage'
 
-EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+# Email Configuration
+EMAIL_BACKEND = os.getenv('DJANGO_EMAIL_BACKEND')
+if os.getenv('DJANGO_RUN_ENV') != 'dev':
+    EMAIL_HOST = os.getenv('DJANGO_EMAIL_HOST')


### PR DESCRIPTION
Per the [Django email documentation](https://docs.djangoproject.com/en/2.2/topics/email/), there are a variety of email back-ends built-in to the framework for sending emails.

For a dev environment, we don't actually want to send any emails to an SMTP relay host. For this we can use Django's [console back-end](https://docs.djangoproject.com/en/2.2/topics/email/#console-backend). 

For a prod environment, where we do want to send emails, we can use Django's [smtp back-end](https://docs.djangoproject.com/en/2.2/topics/email/#smtp-backend). 

I created two new environment variables to store the email configuration:

- `DJANGO_EMAIL_BACKEND`
- `DJANGO_EMAIL_HOST`

When in a dev environment (which is the default for all o the env vars), the `DJANGO_EMAIL_BACKEND` env var will be set to `django.core.mail.backends.console.EmailBackend`.

When in a prod environment (where the env vars are defined in ansible config), the `DJANGO_EMAIL_BACKEND` env var will be set to `django.core.mail.backends.smtp.EmailBackend`.

Also when in a prod environment, the `DJANGO_EMAIL_HOST` env var will be set to the appropriate UCLA Enterprise Messaging SMTP relay host address. 