### PR TITLE
TRRA-135: Include config for DEFAULT_FROM_EMAIL when sending email from terra

### DIFF
--- a/proj/settings.py
+++ b/proj/settings.py
@@ -133,5 +133,6 @@ STATICFILES_STORAGE = 'whitenoise.storage.CompressedStaticFilesStorage'
 
 # Email Configuration
 EMAIL_BACKEND = os.getenv('DJANGO_EMAIL_BACKEND')
+DEFAULT_FROM_EMAIL = 'terra@library.ucla.edu'
 if os.getenv('DJANGO_RUN_ENV') != 'dev':
     EMAIL_HOST = os.getenv('DJANGO_EMAIL_HOST')


### PR DESCRIPTION
When `DEFAULT_FROM_EMAIL` is not set, its default value is `webmaster@localhost`. This appears to cause errors when sending mail via the Django smtp backend. 

To remedy this, we'll set `DEFAULT_FROM_EMAIL` to `terra@library.ucla.edu`. While this isn't a real email address that anyone can reply to, it does match the library's domain and _should_ be allowed by the campus relay server. 