### PR TITLE
TRRA-152: Changed Days Out headings on Employee Detail Report.

### DIFF
--- a/terra/templates/terra/employee.html
+++ b/terra/templates/terra/employee.html
@@ -24,14 +24,14 @@
                 <th scope="col">Activity</th>
                 <th scope="col">Dates</th>
                 <th scope="col">Admin</th>
-                <th scope="col">Days OOO</th>
-                <th scope="col">Vacation Days</th>                
                 <th scope="col">Approved</th>
                 <th scope="col">Funded</th>
                 <th scope="col">Closed</th>
                 <th scope="col">Estimated Expenses</th>
                 <th scope="col">Approved Funds</th>
                 <th scope="col">Actual Expenses</th>
+                <th scope="col">Days Out Working</th>
+                <th scope="col">Days Out Vacation</th>   
             </tr>
         </thead>
         <tbody>
@@ -40,14 +40,14 @@
                 <td><a href="/treq/{{treq.pk}}">{{treq.activity.name}} </a></td>
                 <td>{{treq.departure_date}} - {{treq.return_date}}</td>
                 <td>{{treq.administrative|check_or_cross|safe}}</td>
-                <td>{{treq.days_ooo}}</td>
-                <td>{{treq.vacation_days}}</td>
                 <td>{{treq.approved|check_or_cross|safe}}</td>
                 <td>{{treq.funded|check_or_cross|safe}}</td>
                 <td>{{treq.closed|check_or_cross|safe}}</td>
                 <td>{{treq.estimated_expenses|currency}}</td>
                 <td>{{treq.approved_funds|currency}}</td>
                 <td>{{treq.actual_expenses|currency}}</td>
+                <td>{{treq.days_ooo}}</td>
+                <td>{{treq.vacation_days}}</td>
             </tr>
     {% endfor %}
         </tbody>


### PR DESCRIPTION
Simple change to the Employee Detail Page labels. Days OOO -> 'Days Out Working' 'Vacation Days' -> 'Days Out Vacation'. I also moved them to the end of the report to match the other report formats