### PR TITLE
In production data, not just the UL is an Executive. I removed the is…

### DIFF
--- a/terra/models.py
+++ b/terra/models.py
@@ -104,10 +104,6 @@ class Employee(models.Model):
             self.user.is_superuser or self.user.groups.filter(name="LBS Staff").exists()
         )
 
-    def is_UL(self):
-        if self.type == "EXEC":
-            return True
-
     def is_unit_manager(self):
         return self.managed_units.count() > 0
 

--- a/terra/templates/terra/base.html
+++ b/terra/templates/terra/base.html
@@ -50,7 +50,7 @@
             <a class="nav-link" href="/fund/">FAU Reports</a>
           </li>
           {% endif %}
-          {% if request.user.employee.has_full_report_access or request.user.employee.is_UL  %}
+          {% if request.user.employee.has_full_report_access %}
           <li class="nav-item">
             <a class="nav-link" href="/employee_type_list/">Employee Type Report</a>
           </li>

--- a/terra/views.py
+++ b/terra/views.py
@@ -273,10 +273,7 @@ class EmployeeTypeListView(LoginRequiredMixin, UserPassesTestMixin, ListView):
     template_name = "terra/employee_type_list.html"
 
     def test_func(self):
-        return (
-            self.request.user.employee.has_full_report_access()
-            or self.request.user.employee.is_UL()
-        )
+        return self.request.user.employee.has_full_report_access()
 
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)


### PR DESCRIPTION
…_UL function so at the moment only LBS has access to the Employee Type Report. I've removed the function from the model until there is a way to distinguish positions (UL vs AUL).