### PR TITLE
TRRA-180: Preserve return value from tests, for Travis

### DIFF
--- a/.travis/build_and_test.sh
+++ b/.travis/build_and_test.sh
@@ -40,6 +40,4 @@ TEST_RETVAL=$?
 ${DOCKER_COMPOSE_TRAVIS} exec django coveralls
 
 # Exit with the return value from the tests
-# Force an error for testing...
-TEST_RETVAL=1 
 exit ${TEST_RETVAL}

--- a/.travis/build_and_test.sh
+++ b/.travis/build_and_test.sh
@@ -33,6 +33,13 @@ fi
 
 # Run the tests
 ${DOCKER_COMPOSE_TRAVIS} exec django /home/django/.local/bin/coverage run --source=terra manage.py test terra
+# Capture return value from tests, or it'll be lost when the next command runs
+TEST_RETVAL=$?
 
-# Send the test report to coveralls.io
+# Send the test report to coveralls.io regardless of tests passing?
 ${DOCKER_COMPOSE_TRAVIS} exec django coveralls
+
+# Exit with the return value from the tests
+# Force an error for testing...
+TEST_RETVAL=1 
+exit ${TEST_RETVAL}


### PR DESCRIPTION
@joshuago78 This fixes the Travis build script by preserving the return code from when the tests run.  I believe it was being lost when the next command ran (coveralls).

I tested with a fake non-zero value and the build failed as expected, so I believe this will work correctly.

After merging, rebase into your branch and push and you should get true info.

My apologies for the problem.