### PR TITLE
Trra 177/fau report changes

### DIFF
--- a/terra/fixtures/sample_data.json
+++ b/terra/fixtures/sample_data.json
@@ -1561,7 +1561,7 @@
     "quantity": null,
     "total": "435.00000",
     "fund": 1,
-    "date_paid": "2020-01-01"
+    "date_paid": "2019-06-30"
   }
 },
 {

--- a/terra/reports.py
+++ b/terra/reports.py
@@ -255,13 +255,7 @@ def get_individual_data_for_fund(employee_ids, fund, start_date=None, end_date=N
     )
 
     profdev_spent = (
-        TravelRequest.objects.filter(
-            traveler=OuterRef("pk"),
-            administrative=False,
-            closed=True,
-            departure_date__gte=start_date,
-            return_date__lte=end_date,
-        )
+        TravelRequest.objects.filter(traveler=OuterRef("pk"), administrative=False)
         .values("traveler__pk")
         .annotate(
             profdev_spent=Sum(
@@ -278,7 +272,6 @@ def get_individual_data_for_fund(employee_ids, fund, start_date=None, end_date=N
         TravelRequest.objects.filter(
             traveler=OuterRef("pk"),
             administrative=True,
-            closed=False,
             departure_date__gte=start_date,
             return_date__lte=end_date,
         )
@@ -288,13 +281,7 @@ def get_individual_data_for_fund(employee_ids, fund, start_date=None, end_date=N
     )
 
     admin_spent = (
-        TravelRequest.objects.filter(
-            traveler=OuterRef("pk"),
-            administrative=True,
-            closed=True,
-            departure_date__gte=start_date,
-            return_date__lte=end_date,
-        )
+        TravelRequest.objects.filter(traveler=OuterRef("pk"), administrative=True)
         .values("traveler__pk")
         .annotate(
             admin_spent=Sum(

--- a/terra/templates/terra/fund.html
+++ b/terra/templates/terra/fund.html
@@ -30,18 +30,21 @@
         <thead class="thead-light">
             <tr>
                 <th colspan="2" scope="colgroup"></th>
-                <th colspan="3" scope="colgroup" class="text-center">Approved Funding</th>
-                <th colspan="3" scope="colgroup" class="text-center">Expenditures</th>
+                <th colspan="2" scope="colgroup" class="text-center">Professional Development</th>
+                <th colspan="2" scope="colgroup" class="text-center bg-light">Administrative</th>
+                <th colspan="2" scope="colgroup" class="text-center">Totals</th>
             </tr>
             <tr>
                 <th scope="col">Employee</th>
                 <th scope="col">Type</th>
-                <th scope="col" class="text-right">Prof. Dev.</th>
-                <th scope="col" class="text-right">Admin.</th>
-                <th scope="col" class="text-right">Total</th>
-                <th scope="col" class="text-right">Prof. Dev.</th>
-                <th scope="col" class="text-right">Admin.</th>
-                <th scope="col" class="text-right">Total</th>
+                <th scope="col" class="text-right">Amount Requested</th>
+                <th scope="col" class="text-right">Amount Spent</th>
+                
+                <th scope="col" class="text-right bg-light">Amount Requested</th>
+                <th scope="col" class="text-right bg-light">Amount Spent</th>
+
+                <th scope="col" class="text-right">Total Requested</th>
+                <th scope="col" class="text-right">Total Spent</th>
             </tr>
         </thead>
         <tbody>
@@ -49,12 +52,14 @@
             <tr>
                 <td><a href="/employee/{{employee.pk}}/">{{employee.user.last_name}}, {{employee.user.first_name}}</a></td>
                 <td>{{employee.get_type_display}}</td>
-                <td class="text-right">{{employee.profdev_alloc|currency}}</td>
-                <td class="text-right">{{employee.admin_alloc|currency}}</td>
-                <td class="text-right">{{employee.total_alloc|currency}}</td>
-                <td class="text-right">{{employee.profdev_expend|currency}}</td>
-                <td class="text-right">{{employee.admin_expend|currency}}</td>
-                <td class="text-right">{{employee.total_expend|currency}}</td>
+                <td class="text-right">{{employee.profdev_requested|currency}}</td>
+                <td class="text-right">{{employee.profdev_spent|currency}}</td>
+
+                <td class="text-right">{{employee.admin_requested|currency}}</td>
+                <td class="text-right">{{employee.admin_spent|currency}}</td>
+
+                <td class="text-right">{{employee.total_requested|currency}}</td>
+                <td class="text-right">{{employee.total_spent|currency}}</td>
             </tr>
             {% endfor %}
         </tbody>
@@ -62,12 +67,14 @@
             <tr>
                 <th>Totals</th>
                 <th></th>
-                <th class="text-right">{{totals.profdev_alloc|currency}}</th>
-                <th class="text-right">{{totals.admin_alloc|currency}}</th>
-                <th class="text-right">{{totals.total_alloc|currency}}</th>
-                <th class="text-right">{{totals.profdev_expend|currency}}</th>
-                <th class="text-right">{{totals.admin_expend|currency}}</th>
-                <th class="text-right">{{totals.total_expend|currency}}</th>
+                <th class="text-right">{{totals.profdev_requested|currency}}</th>
+                <th class="text-right">{{totals.profdev_spent|currency}}</th>
+
+                <th class="text-right">{{totals.admin_requested|currency}}</th>
+                <th class="text-right">{{totals.admin_spent|currency}}</th>
+
+                <th class="text-right">{{totals.total_requested|currency}}</th>
+                <th class="text-right">{{totals.total_spent|currency}}</th>
             </tr>
         </tfoot>
     </table>

--- a/terra/tests.py
+++ b/terra/tests.py
@@ -485,9 +485,9 @@ class UnitReportsTestCase(TestCase):
                         "profdev_requested": Decimal("4000"),
                         "admin_requested": Decimal("2350"),
                         "total_requested": Decimal("6350"),
-                        "profdev_spent": Decimal("3695"),
+                        "profdev_spent": Decimal("3260"),
                         "admin_spent": Decimal("0"),
-                        "total_spent": Decimal("3695"),
+                        "total_spent": Decimal("3260"),
                         "days_vacation": Decimal("14"),
                         "days_away": Decimal("33"),
                     }
@@ -521,9 +521,9 @@ class UnitReportsTestCase(TestCase):
                 "admin_requested": Decimal("2350"),
                 "admin_spent": Decimal("0"),
                 "profdev_requested": Decimal("4000"),
-                "profdev_spent": Decimal("3695"),
+                "profdev_spent": Decimal("3260"),
                 "total_requested": Decimal("6350"),
-                "total_spent": Decimal("3695"),
+                "total_spent": Decimal("3260"),
                 "days_vacation": Decimal("14"),
                 "days_away": Decimal("33"),
             },
@@ -587,9 +587,9 @@ class FundReportsTestCase(TestCase):
             "admin_requested": Decimal("1050"),
             "admin_spent": Decimal("0"),
             "profdev_requested": Decimal("3500.00000"),
-            "profdev_spent": Decimal("3695"),
+            "profdev_spent": Decimal("3260"),
             "total_requested": Decimal("4550.00000"),
-            "total_spent": Decimal("3695"),
+            "total_spent": Decimal("3260"),
         }
         fund = Fund.objects.get(pk=1)
         employees, totals = reports.fund_report(fund)
@@ -943,14 +943,16 @@ class EmployeeSubtotalTestCase(TestCase):
             "total_estimatedexpense": Decimal("6075.0000"),
             "profdev_requested": Decimal("2000.0000"),
             "profdev_spent": Decimal("1855.0000"),
-            "total_requested": 0,
+            "total_requested": Decimal(2000),
             "total_days_ooo": 20,
-            "total_spent": Decimal("0.0000"),
+            "total_spent": Decimal("1855.0000"),
         }
         employee_ids = [2]
         start_date = date(2019, 7, 1)
         end_date = date(2020, 6, 30)
-        actual = reports.get_individual_data(employee_ids, start_date, end_date)
+        actual = reports.get_individual_data_employee(
+            employee_ids, start_date, end_date
+        )
         for x in actual:
             for key, value in x.items():
                 with self.subTest(key=key, value=value):

--- a/terra/tests.py
+++ b/terra/tests.py
@@ -584,12 +584,12 @@ class FundReportsTestCase(TestCase):
 
     def test_fund_report(self):
         expected = {
-            "admin_alloc": Decimal("1050"),
-            "admin_expend": Decimal("0"),
-            "profdev_alloc": Decimal("7195"),
-            "profdev_expend": Decimal("3695"),
-            "total_alloc": Decimal("8245"),
-            "total_expend": Decimal("3695"),
+            "admin_requested": Decimal("1050"),
+            "admin_spent": Decimal("0"),
+            "profdev_requested": Decimal("3500.00000"),
+            "profdev_spent": Decimal("3695"),
+            "total_requested": Decimal("4550.00000"),
+            "total_spent": Decimal("3695"),
         }
         fund = Fund.objects.get(pk=1)
         employees, totals = reports.fund_report(fund)

--- a/terra/views.py
+++ b/terra/views.py
@@ -223,12 +223,12 @@ class FundExportView(FundDetailView):
             [
                 "Employee",
                 "Type",
-                "Prof Dev Approved",
-                "Admin Approved",
-                "Total Approved",
-                "Prof Dev Expenditures",
-                "Admin Expenditures",
-                "Total Expenditures",
+                "Prof Dev Requested",
+                "Prof Dev Spent",
+                "Admin Requested",
+                "Admin Spent",
+                "Total Requested",
+                "Total Spent",
             ]
         )
         for e in context["employees"]:
@@ -236,24 +236,24 @@ class FundExportView(FundDetailView):
                 [
                     f"{e.user.last_name}, {e.user.first_name}",
                     e.get_type_display(),
-                    e.profdev_alloc,
-                    e.admin_alloc,
-                    e.total_alloc,
-                    e.profdev_expend,
-                    e.admin_expend,
-                    e.total_expend,
+                    e.profdev_requested,
+                    e.profdev_spent,
+                    e.admin_requested,
+                    e.admin_spent,
+                    e.total_requested,
+                    e.total_spent,
                 ]
             )
         writer.writerow(
             [
                 "Totals",
                 "",
-                totals["profdev_alloc"],
-                totals["admin_alloc"],
-                totals["total_alloc"],
-                totals["profdev_expend"],
-                totals["admin_expend"],
-                totals["total_expend"],
+                totals["profdev_requested"],
+                totals["profdev_spent"],
+                totals["admin_requested"],
+                totals["admin_spent"],
+                totals["total_requested"],
+                totals["total_spent"],
             ]
         )
         return response


### PR DESCRIPTION
Updated FAU report to base spent amount on fiscal year of paid_date for actual expenses to match the Unit Report
-removed treq date in fund employee list query
-changed `alloc` to `requested`
-changed `expend` to `spent`
-removed replacement of spent expenditures for allocations 
-updated template to reflect new variable names
-updated tests
 Also looks like the reformatting was picked up as changes for the unit report individual query