### PR TITLE
Trra 141/color indicators

### DIFF
--- a/terra/fixtures/sample_data.json
+++ b/terra/fixtures/sample_data.json
@@ -1135,7 +1135,7 @@
     "funded_by": 3,
     "treq": 1,
     "fund": 1,
-    "amount": "1500.00000"
+    "amount": "3500.00000"
   }
 },
 {
@@ -1585,7 +1585,7 @@
     "type": "LDG",
     "rate": null,
     "quantity": null,
-    "total": "915.00000",
+    "total": "2000.00000",
     "fund": 1,
     "date_paid": "2020-01-01"
   }

--- a/terra/templates/terra/employee_type_list.html
+++ b/terra/templates/terra/employee_type_list.html
@@ -57,8 +57,8 @@
                 <td>{{employee.unit_manager}}</td>
                 <td><a href="/employee/{{employee.id}}/">{{employee.name}}</a></td>
 
-                <td class="text-right">{{employee.profdev_requested|currency}}</td>
-                <td class="text-right">{{employee.profdev_spent|currency}}</td>
+                <td class="text-right">{{employee.profdev_requested|cap|safe}}</td>
+                <td class="text-right">{{employee.profdev_spent|cap|safe}}</td>
 
                 <td class="text-right">{{employee.admin_requested|currency}}</td>
                 <td class="text-right">{{employee.admin_spent|currency}}</td>

--- a/terra/templates/terra/fund.html
+++ b/terra/templates/terra/fund.html
@@ -52,8 +52,8 @@
             <tr>
                 <td><a href="/employee/{{employee.pk}}/">{{employee.user.last_name}}, {{employee.user.first_name}}</a></td>
                 <td>{{employee.get_type_display}}</td>
-                <td class="text-right">{{employee.profdev_requested|currency}}</td>
-                <td class="text-right">{{employee.profdev_spent|currency}}</td>
+                <td class="text-right">{{employee.profdev_requested|cap|safe}}</td>
+                <td class="text-right">{{employee.profdev_spent|cap|safe}}</td>
 
                 <td class="text-right">{{employee.admin_requested|currency}}</td>
                 <td class="text-right">{{employee.admin_spent|currency}}</td>

--- a/terra/templates/terra/unit.html
+++ b/terra/templates/terra/unit.html
@@ -58,8 +58,8 @@
                 <td><a href="/employee/{{employee.pk}}/">{{employee.user.last_name}}, {{employee.user.first_name}}</a></td>
                 <td> {{employee.get_type_display}}</td>
 
-                <td class="text-right">{{employee.data.profdev_requested|currency}}</td>
-                <td class="text-right">{{employee.data.profdev_spent|currency}}</td>
+                <td class="text-right">{{employee.data.profdev_requested|cap|safe}}</td>
+                <td class="text-right">{{employee.data.profdev_spent|cap|safe}}</td>
                 
                 <td class="text-right">{{employee.data.admin_requested|currency}}</td>
                 <td class="text-right">{{employee.data.admin_spent|currency}}</td>

--- a/terra/templatetags/terra_extras.py
+++ b/terra/templatetags/terra_extras.py
@@ -24,12 +24,12 @@ def cap(value):
         value = 0
         return format_currency(value, grouping=True)
     if value >= 3500:
-        return '<span class="badge badge-danger">{}</span>'.format(
+        return '<span class="alert-danger">{}</span>'.format(
             format_currency(value, grouping=True)
         )
         # Over or at professional development cap
     elif value >= 2800 and value < 3500:
-        return '<span class="badge badge-warning">{}</span>'.format(
+        return '<span class="alert-warning">{}</span>'.format(
             format_currency(value, grouping=True)
         )
         # Within 20% of professional development cap

--- a/terra/templatetags/terra_extras.py
+++ b/terra/templatetags/terra_extras.py
@@ -20,7 +20,9 @@ def currency(value):
 
 @register.filter
 def cap(value):
-
+    if value is None or value == "":
+        value = 0
+        return format_currency(value, grouping=True)
     if value >= 3500:
         return '<span class="badge badge-danger">{}</span>'.format(
             format_currency(value, grouping=True)

--- a/terra/templatetags/terra_extras.py
+++ b/terra/templatetags/terra_extras.py
@@ -20,9 +20,16 @@ def currency(value):
 
 @register.filter
 def cap(value):
+
     if value >= 3500:
-        return '<span class="badge badge-pill badge-danger">{}</span>'.format(value)
+        return '<span class="badge badge-danger">{}</span>'.format(
+            format_currency(value, grouping=True)
+        )
+        # over or at professional development cap
     elif value >= 2800:
-        return '<span class="badge badge-pill badge-warning">{}</span>'.format(value)
+        return '<span class="badge badge-warning">{}</span>'.format(
+            format_currency(value, grouping=True)
+        )
+        # Within 20% of professional development cap
     else:
-        return value
+        return format_currency(value, grouping=True)

--- a/terra/templatetags/terra_extras.py
+++ b/terra/templatetags/terra_extras.py
@@ -25,8 +25,8 @@ def cap(value):
         return '<span class="badge badge-danger">{}</span>'.format(
             format_currency(value, grouping=True)
         )
-        # over or at professional development cap
-    elif value >= 2800:
+        # Over or at professional development cap
+    elif value >= 2800 and value < 3500:
         return '<span class="badge badge-warning">{}</span>'.format(
             format_currency(value, grouping=True)
         )

--- a/terra/templatetags/terra_extras.py
+++ b/terra/templatetags/terra_extras.py
@@ -13,6 +13,16 @@ def check_or_cross(bool):
 
 @register.filter
 def currency(value):
-    if value is None or value=="":
+    if value is None or value == "":
         value = 0
     return format_currency(value, grouping=True)
+
+
+@register.filter
+def cap(value):
+    if value >= 3500:
+        return '<span class="badge badge-pill badge-danger">{}</span>'.format(value)
+    elif value >= 2800:
+        return '<span class="badge badge-pill badge-warning">{}</span>'.format(value)
+    else:
+        return value

--- a/terra/tests.py
+++ b/terra/tests.py
@@ -482,12 +482,12 @@ class UnitReportsTestCase(TestCase):
             "subunits": {
                 2: {
                     "subunit_totals": {
-                        "profdev_requested": Decimal("4000"),
+                        "profdev_requested": Decimal("6000"),
                         "admin_requested": Decimal("2350"),
-                        "total_requested": Decimal("6350"),
-                        "profdev_spent": Decimal("3260"),
+                        "total_requested": Decimal("8350"),
+                        "profdev_spent": Decimal("4345"),
                         "admin_spent": Decimal("0"),
-                        "total_spent": Decimal("3260"),
+                        "total_spent": Decimal("4345"),
                         "days_vacation": Decimal("14"),
                         "days_away": Decimal("33"),
                     }
@@ -520,10 +520,10 @@ class UnitReportsTestCase(TestCase):
             "unit_totals": {
                 "admin_requested": Decimal("2350"),
                 "admin_spent": Decimal("0"),
-                "profdev_requested": Decimal("4000"),
-                "profdev_spent": Decimal("3260"),
-                "total_requested": Decimal("6350"),
-                "total_spent": Decimal("3260"),
+                "profdev_requested": Decimal("6000"),
+                "profdev_spent": Decimal("4345"),
+                "total_requested": Decimal("8350"),
+                "total_spent": Decimal("4345"),
                 "days_vacation": Decimal("14"),
                 "days_away": Decimal("33"),
             },
@@ -586,10 +586,10 @@ class FundReportsTestCase(TestCase):
         expected = {
             "admin_requested": Decimal("1050"),
             "admin_spent": Decimal("0"),
-            "profdev_requested": Decimal("3500.00000"),
-            "profdev_spent": Decimal("3260"),
-            "total_requested": Decimal("4550.00000"),
-            "total_spent": Decimal("3260"),
+            "profdev_requested": Decimal("5500.00000"),
+            "profdev_spent": Decimal("4345"),
+            "total_requested": Decimal("6550.00000"),
+            "total_spent": Decimal("4345"),
         }
         fund = Fund.objects.get(pk=1)
         employees, totals = reports.fund_report(fund)
@@ -780,7 +780,7 @@ class EmployeeTypeReportsTestCase(TestCase):
                     "employees": [
                         {
                             "id": 2,
-                            "profdev_requested": Decimal("2000.00000"),
+                            "profdev_requested": Decimal("4000.00000"),
                             "profdev_spent": Decimal("1420.00000"),
                             "admin_requested": Decimal("0.00000"),
                             "admin_spent": Decimal("0.00000"),
@@ -789,7 +789,7 @@ class EmployeeTypeReportsTestCase(TestCase):
                             "name": "Prigge, Ashton",
                             "unit": "Software Development & Library Systems",
                             "unit_manager": "Gomez, Joshua",
-                            "total_requested": Decimal("2000.00000"),
+                            "total_requested": Decimal("4000.00000"),
                             "total_spent": Decimal("1420.00000"),
                             "total_days_ooo": 20,
                         }
@@ -799,9 +799,9 @@ class EmployeeTypeReportsTestCase(TestCase):
                         "admin_spent": Decimal("0.00000"),
                         "days_away": 15,
                         "days_vacation": 5,
-                        "profdev_requested": Decimal("2000.00000"),
+                        "profdev_requested": Decimal("4000.00000"),
                         "profdev_spent": Decimal("1420.00000"),
-                        "total_requested": Decimal("2000.00000"),
+                        "total_requested": Decimal("4000.00000"),
                         "total_days_ooo": 20,
                         "total_spent": Decimal("1420.00000"),
                     },
@@ -811,7 +811,7 @@ class EmployeeTypeReportsTestCase(TestCase):
                         {
                             "id": 5,
                             "profdev_requested": Decimal("0.00000"),
-                            "profdev_spent": Decimal("1840.00000"),
+                            "profdev_spent": Decimal("2925.00000"),
                             "admin_requested": Decimal("0.00000"),
                             "admin_spent": Decimal("0.00000"),
                             "days_vacation": 0,
@@ -820,7 +820,7 @@ class EmployeeTypeReportsTestCase(TestCase):
                             "unit": "Software Development & Library Systems",
                             "unit_manager": "Gomez, Joshua",
                             "total_requested": Decimal("0.00000"),
-                            "total_spent": Decimal("1840.00000"),
+                            "total_spent": Decimal("2925.00000"),
                             "total_days_ooo": 5,
                         }
                     ],
@@ -830,10 +830,10 @@ class EmployeeTypeReportsTestCase(TestCase):
                         "days_away": 5,
                         "days_vacation": 0,
                         "profdev_requested": Decimal("0.00000"),
-                        "profdev_spent": Decimal("1840.00000"),
+                        "profdev_spent": Decimal("2925.00000"),
                         "total_requested": Decimal("0.00000"),
                         "total_days_ooo": 5,
-                        "total_spent": Decimal("1840.00000"),
+                        "total_spent": Decimal("2925.00000"),
                     },
                 },
                 "Other": {
@@ -856,11 +856,11 @@ class EmployeeTypeReportsTestCase(TestCase):
                 "admin_spent": Decimal("0.00000"),
                 "days_away": 33,
                 "days_vacation": 14,
-                "profdev_requested": Decimal("4000.00000"),
-                "profdev_spent": Decimal("3260.00000"),
-                "total_requested": Decimal("6350.00000"),
+                "profdev_requested": Decimal("6000.00000"),
+                "profdev_spent": Decimal("4345.00000"),
+                "total_requested": Decimal("8350.00000"),
                 "total_days_ooo": 47,
-                "total_spent": Decimal("3260.00000"),
+                "total_spent": Decimal("4345.00000"),
             },
         }
 
@@ -942,9 +942,9 @@ class EmployeeSubtotalTestCase(TestCase):
             "days_away": 15,
             "days_vacation": 5,
             "total_estimatedexpense": Decimal("6075.0000"),
-            "profdev_requested": Decimal("2000.0000"),
+            "profdev_requested": Decimal("4000.0000"),
             "profdev_spent": Decimal("1855.0000"),
-            "total_requested": Decimal(2000),
+            "total_requested": Decimal(4000),
             "total_days_ooo": 20,
             "total_spent": Decimal("1855.0000"),
         }


### PR DESCRIPTION
In unit, fau, and employee type reports:
-Adds yellow indicator if prof dev amounts are between $2800 and $3500 
-Adds red indicator if prof dev amounts are equal to or greater than $3500
-Updated sample data to include amounts that exceed $2800 and $3500
-Updated tests to match new values

Admin and prof dev days out are grouped together at the moment, so we can't isolate just prof dev days out to highlight if they are approaching the cap.