### PR TITLE
Added filter to FAU subqueries to ensure they only retrieve TREQs for that FAU

### DIFF
--- a/terra/admin.py
+++ b/terra/admin.py
@@ -191,8 +191,11 @@ class FundAdmin(admin.ModelAdmin):
 
 @admin.register(Funding)
 class FundingAdmin(admin.ModelAdmin):
-    list_display = ("id", "treq", "funded_by", "funded_on", "fund", "amount")
-    list_filter = (("funded_on", custom_titled_filter("funding date")),)
+    list_display = ("id", "treq", "fund", "funded_by", "funded_on", "amount")
+    list_filter = (
+        "fund",
+        ("funded_on", custom_titled_filter("funding date")),
+    )
     search_fields = [
         "treq__traveler__user__last_name",
         "treq__traveler__user__first_name",
@@ -215,8 +218,8 @@ class EstimatedExpenseAdmin(admin.ModelAdmin):
 
 @admin.register(ActualExpense)
 class ActualExpenseAdmin(admin.ModelAdmin):
-    list_display = ("id", "treq", "type", "total_dollars", "date_paid")
-    list_filter = ("type", ("total", custom_titled_filter("total cost")))
+    list_display = ("id", "treq", "fund", "type", "total_dollars", "date_paid")
+    list_filter = ("type", "fund")
     search_fields = [
         "treq__traveler__user__last_name",
         "treq__traveler__user__first_name",

--- a/terra/reports.py
+++ b/terra/reports.py
@@ -288,7 +288,7 @@ def get_individual_data_for_fund(employee_ids, fund, start_date=None, end_date=N
 
     profdev_spent = (
         TravelRequest.objects.filter(
-            traveler=OuterRef("pk"), administrative=False, funding__fund=fund
+            traveler=OuterRef("pk"), administrative=False, actualexpense__fund=fund
         )
         .values("traveler__pk")
         .annotate(
@@ -317,7 +317,7 @@ def get_individual_data_for_fund(employee_ids, fund, start_date=None, end_date=N
 
     admin_spent = (
         TravelRequest.objects.filter(
-            traveler=OuterRef("pk"), administrative=True, funding__fund=fund
+            traveler=OuterRef("pk"), administrative=True, actualexpense__fund=fund
         )
         .values("traveler__pk")
         .annotate(

--- a/terra/reports.py
+++ b/terra/reports.py
@@ -277,6 +277,7 @@ def get_individual_data_for_fund(employee_ids, fund, start_date=None, end_date=N
             administrative=False,
             departure_date__gte=start_date,
             return_date__lte=end_date,
+            funding__fund=fund,
         )
         .values("traveler__pk")
         .annotate(
@@ -286,7 +287,9 @@ def get_individual_data_for_fund(employee_ids, fund, start_date=None, end_date=N
     )
 
     profdev_spent = (
-        TravelRequest.objects.filter(traveler=OuterRef("pk"), administrative=False)
+        TravelRequest.objects.filter(
+            traveler=OuterRef("pk"), administrative=False, funding__fund=fund
+        )
         .values("traveler__pk")
         .annotate(
             profdev_spent=Sum(
@@ -305,6 +308,7 @@ def get_individual_data_for_fund(employee_ids, fund, start_date=None, end_date=N
             administrative=True,
             departure_date__gte=start_date,
             return_date__lte=end_date,
+            funding__fund=fund,
         )
         .values("traveler__pk")
         .annotate(admin_requested=Sum("funding__amount"), filter=Q(funding__fund=fund))
@@ -312,7 +316,9 @@ def get_individual_data_for_fund(employee_ids, fund, start_date=None, end_date=N
     )
 
     admin_spent = (
-        TravelRequest.objects.filter(traveler=OuterRef("pk"), administrative=True)
+        TravelRequest.objects.filter(
+            traveler=OuterRef("pk"), administrative=True, funding__fund=fund
+        )
         .values("traveler__pk")
         .annotate(
             admin_spent=Sum(
@@ -328,16 +334,27 @@ def get_individual_data_for_fund(employee_ids, fund, start_date=None, end_date=N
     # final query
     rows = Employee.objects.filter(pk__in=employee_ids).annotate(
         profdev_requested=Coalesce(
-            Subquery(profdev_requested, output_field=DecimalField()), Value(0)
+            Subquery(
+                profdev_requested.values("profdev_requested"),
+                output_field=DecimalField(),
+            ),
+            Value(0),
         ),
         profdev_spent=Coalesce(
-            Subquery(profdev_spent, output_field=DecimalField()), Value(0)
+            Subquery(
+                profdev_spent.values("profdev_spent"), output_field=DecimalField()
+            ),
+            Value(0),
         ),
         admin_requested=Coalesce(
-            Subquery(admin_requested, output_field=DecimalField()), Value(0)
+            Subquery(
+                admin_requested.values("admin_requested"), output_field=DecimalField()
+            ),
+            Value(0),
         ),
         admin_spent=Coalesce(
-            Subquery(admin_spent, output_field=DecimalField()), Value(0)
+            Subquery(admin_spent.values("admin_spent"), output_field=DecimalField()),
+            Value(0),
         ),
     )
     return rows


### PR DESCRIPTION
The error occurred when the FAU report encountered a person with more than one `admin_requested` value. This was happening because the `admin_requested` and `profdev_requested` subqueries retrieved all Treqs for a given employee, not just ones with funding from the given FAU. Thus, the aggregate `Sum` function was performed on multiple FAUs for people that had trips on more than one fund. I fixed this by adding `funding__fund=fund` in the initial TravelRequest filter.