### PR TITLE
Trra 186/fy change employeetype

### DIFF
--- a/proj/settings.py
+++ b/proj/settings.py
@@ -67,6 +67,7 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
+                "terra.context_processors.add_variable_to_context",
             ]
         },
     }

--- a/proj/urls.py
+++ b/proj/urls.py
@@ -105,12 +105,12 @@ urlpatterns = [
         name="fund_list",
     ),
     path(
-        "employee_type_list/",
+        "employee_type_list/<int:year>/",
         EmployeeTypeListView.as_view(template_name="terra/employee_type_list.html"),
         name="employee_type_list",
     ),
     path(
-        "employee_type_list/export/",
+        "employee_type_list/<int:year>/export/",
         EmployeeTypeExportView.as_view(),
         name="employee_type_csv",
     ),

--- a/terra/context_processors.py
+++ b/terra/context_processors.py
@@ -1,21 +1,4 @@
-from datetime import date
-from django.conf import settings
-
-import fiscalyear as FY
-import locale
-
-
-FY.START_MONTH = 7
-
-
-def current_fiscal_year(today=None):
-    today = date.today() if today is None else today
-    return FY.FiscalDate(today.year, today.month, today.day).fiscal_year
-
-
-def current_fiscal_year_int(today=None):
-    year = current_fiscal_year(today=today)
-    return year
+from .utils import current_fiscal_year_int
 
 
 def add_variable_to_context(request):

--- a/terra/context_processors.py
+++ b/terra/context_processors.py
@@ -1,0 +1,22 @@
+from datetime import date
+from django.conf import settings
+
+import fiscalyear as FY
+import locale
+
+
+FY.START_MONTH = 7
+
+
+def current_fiscal_year(today=None):
+    today = date.today() if today is None else today
+    return FY.FiscalDate(today.year, today.month, today.day).fiscal_year
+
+
+def current_fiscal_year_int(today=None):
+    year = current_fiscal_year(today=today)
+    return year
+
+
+def add_variable_to_context(request):
+    return {"fy_year": current_fiscal_year_int()}

--- a/terra/templates/terra/base.html
+++ b/terra/templates/terra/base.html
@@ -1,6 +1,5 @@
 <!doctype html>
 {% load static %}
-{% load terra_extras %}
 <html lang="en">
   <head>
     <!-- Required meta tags -->

--- a/terra/templates/terra/base.html
+++ b/terra/templates/terra/base.html
@@ -1,5 +1,6 @@
 <!doctype html>
 {% load static %}
+{% load terra_extras %}
 <html lang="en">
   <head>
     <!-- Required meta tags -->
@@ -38,6 +39,7 @@
       <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#header" aria-controls="navbarsExampleDefault" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>
+
       <div class="collapse navbar-collapse" id="header">
         <ul class="navbar-nav mr-auto">
           <li class="nav-item">
@@ -55,7 +57,7 @@
           {% endif %}
           {% if request.user.employee.has_full_report_access or request.user.employee.is_UL  %}
           <li class="nav-item">
-            <a class="nav-link" href="/employee_type_list/">Employee Type Report</a>
+            <a class="nav-link" href="/employee_type_list/{{fy_year}}/">Employee Type Report</a>
           </li>
           {% endif %}
           {% if request.user.employee.has_full_report_access %}

--- a/terra/templates/terra/employee_type_list.html
+++ b/terra/templates/terra/employee_type_list.html
@@ -20,9 +20,23 @@
             <h2>Employee Type Report</h2>
             <br>
         </div>
+
         <div class="col text-right">
-            <a href="/employee_type_list/export" class="btn btn-primary" role="button" aria-pressed="true">Download CSV</a>
+            <a href="{% url 'employee_type_csv' year=fy %}" class="btn btn-primary" role="button" aria-pressed="true">Download CSV</a>
         </div>
+
+        <div class="dropdown">
+            <button class="btn btn-light dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            Fiscal Year
+            </button>
+            <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
+                {% for year in fiscal_year_list %}
+                    <a class="dropdown-item" href= "/employee_type_list/{{year}}">{{year}}</a>
+                {% endfor %}
+            </div>
+        </div>
+    </div>
+
     </div>
 {% for key, value in merge.type.items %}
     <table class="table">

--- a/terra/templatetags/terra_extras.py
+++ b/terra/templatetags/terra_extras.py
@@ -55,9 +55,3 @@ def days_cap(value):
         # Within 20% of professional development cap
     else:
         return value
-
-
-@register.filter
-def current_fiscal_year(today=None):
-    today = date.today() if today is None else today
-    return FiscalDate(today.year, today.month, today.day).fiscal_year

--- a/terra/templatetags/terra_extras.py
+++ b/terra/templatetags/terra_extras.py
@@ -1,5 +1,10 @@
 from django import template
 from terra.utils import format_currency
+from datetime import date
+from django.conf import settings
+
+import fiscalyear as FY
+import locale
 
 register = template.Library()
 
@@ -50,3 +55,9 @@ def days_cap(value):
         # Within 20% of professional development cap
     else:
         return value
+
+
+@register.filter
+def current_fiscal_year(today=None):
+    today = date.today() if today is None else today
+    return FiscalDate(today.year, today.month, today.day).fiscal_year

--- a/terra/tests.py
+++ b/terra/tests.py
@@ -375,7 +375,7 @@ class TestUnitListView(TestCase):
 #         call_command("load_units", "terra/fixtures/test_units.csv")
 #         call_command("load_employees", "terra/fixtures/test_employees.csv")
 #         call_command("load_travel_data", "terra/fixtures/test_travel_data.csv")
- 
+
 #     def test_load_units(self):
 #         unit_count = Unit.objects.all().count()
 #         self.assertEqual(unit_count, 3)
@@ -925,25 +925,25 @@ class EmployeeTypeReportsTestCase(TestCase):
             )
 
     def test_type_report_denies_anonymous(self):
-        response = self.client.get("/employee_type_list/", follow=True)
+        response = self.client.get("/employee_type_list/2020/", follow=True)
         self.assertRedirects(
-            response, "/accounts/login/?next=/employee_type_list/", status_code=302
+            response, "/accounts/login/?next=/employee_type_list/2020/", status_code=302
         )
 
     def test_type_report_allows_full_access(self):
         self.client.login(username="doriswang", password="Staples50141")
-        response = self.client.get("/employee_type_list/")
+        response = self.client.get("/employee_type_list/2020/")
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "terra/employee_type_list.html")
 
     def test_type_report_denies_non_UL(self):
         self.client.login(username="tgrappone", password="Staples50141")
-        response = self.client.get("/employee_type_list/")
+        response = self.client.get("/employee_type_list/2020/")
         self.assertEqual(response.status_code, 403)
 
     def test_type_report_allows_UL(self):
         self.client.login(username="vsteel", password="Staples50141")
-        response = self.client.get("/employee_type_list/")
+        response = self.client.get("/employee_type_list/2020/")
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "terra/employee_type_list.html")
 

--- a/terra/views.py
+++ b/terra/views.py
@@ -32,6 +32,13 @@ def home(request):
     )
 
 
+@login_required
+def employee_type_list(request):
+    return HttpResponseRedirect(
+        reverse("employee_type_list", kwargs={"year": current_fiscal_year_int()})
+    )
+
+
 class EmployeeDetailView(LoginRequiredMixin, UserPassesTestMixin, DetailView):
 
     model = Employee

--- a/terra/views.py
+++ b/terra/views.py
@@ -309,7 +309,8 @@ class EmployeeTypeListView(LoginRequiredMixin, UserPassesTestMixin, ListView):
         context = super().get_context_data(*args, **kwargs)
         # For now get current fiscal year
         # Override this by query params when we add historic data
-        fy = current_fiscal_year_object()
+        fy = fiscal_year(fiscal_year=self.kwargs["year"])
+        context["fy"] = self.kwargs["year"]
         id_list = []
         for employee in Employee.objects.all():
             id_list.append(employee.id)
@@ -317,16 +318,17 @@ class EmployeeTypeListView(LoginRequiredMixin, UserPassesTestMixin, ListView):
             employee_ids=id_list, start_date=fy.start.date(), end_date=fy.end.date()
         )
         context["fiscalyear"] = "{} - {}".format(fy.start.year, fy.end.year)
+        context["fiscal_year_list"] = fiscal_year_list()
         return context
 
 
 class EmployeeTypeExportView(EmployeeTypeListView):
     def render_to_response(self, context, **response_kwargs):
-        fy = context.get("fiscalyear", "").replace(" ", "")
+        fy = fiscal_year(fiscal_year=self.kwargs["year"])
         response = HttpResponse(content_type="text/csv")
         response[
             "Content-Disposition"
-        ] = f'attachment; filename="Employee_Type_FY{fy}.csv"'
+        ] = f'attachment; filename="Employee_Type_{fy}.csv"'
         writer = csv.writer(response)
         writer.writerow(
             [


### PR DESCRIPTION
-updated urls to specify fiscal year
-report changes data queried based on fiscal year specified in URL
-page has dropdown to select FY from inception date (previously set in settings.py)
-page defaults to current fiscal year via dictionary from new context processor to pass current fy to base template
-export is for selected FY only
-updated tests for new url structure