### PR TITLE
Trra 185/fau report fiscalyear

### DIFF
--- a/proj/urls.py
+++ b/proj/urls.py
@@ -93,9 +93,9 @@ urlpatterns = [
         UnitListView.as_view(template_name="terra/unit_list.html"),
         name="unit_list",
     ),
-    path("fund/<int:pk>/export/", FundExportView.as_view(), name="fund_csv"),
+    path("fund/<int:pk>/<int:year>/export/", FundExportView.as_view(), name="fund_csv"),
     path(
-        "fund/<int:pk>/",
+        "fund/<int:pk>/<int:year>/",
         FundDetailView.as_view(template_name="terra/fund.html"),
         name="fund_detail",
     ),

--- a/terra/templates/terra/fund.html
+++ b/terra/templates/terra/fund.html
@@ -22,7 +22,7 @@
             <h3>{{fund}}</h3>
         </div>
         <div class="col text-right">
-            <a href="/fund/{{fund.pk}}/export/" class="btn btn-primary" role="button" aria-pressed="true">Download CSV</a>
+            <a href="{% url 'fund_csv' pk=fund.id year=fy %}" class="btn btn-primary" role="button" aria-pressed="true">Download CSV</a>
         </div>
     </div>
 

--- a/terra/templates/terra/fund.html
+++ b/terra/templates/terra/fund.html
@@ -24,6 +24,17 @@
         <div class="col text-right">
             <a href="{% url 'fund_csv' pk=fund.id year=fy %}" class="btn btn-primary" role="button" aria-pressed="true">Download CSV</a>
         </div>
+
+        <div class="dropdown">
+            <button class="btn btn-light dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            Fiscal Year
+            </button>
+            <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
+                {% for year in fiscal_year_list %}
+                    <a class="dropdown-item" href= "/fund/{{fund.id}}/{{year}}">{{year}}</a>
+                {% endfor %}
+            </div>
+        </div>
     </div>
 
     <table class="table">

--- a/terra/templates/terra/fund_list.html
+++ b/terra/templates/terra/fund_list.html
@@ -26,7 +26,7 @@
   </thead>
   <tbody>
   	{% for fund in funds %}
-  	<tr class="table-row" data-href="/fund/{{fund.pk}}">
+  	<tr class="table-row" data-href="{% url 'fund_detail' pk=fund.id year=current_fy %}">
   		<td>{{ fund }}</td>
   		<td>{% if fund.unit %}{{ fund.unit }}{% endif %}</td>
   		<td>{{ fund.manager }}</td>

--- a/terra/tests.py
+++ b/terra/tests.py
@@ -375,7 +375,7 @@ class TestUnitListView(TestCase):
 #         call_command("load_units", "terra/fixtures/test_units.csv")
 #         call_command("load_employees", "terra/fixtures/test_employees.csv")
 #         call_command("load_travel_data", "terra/fixtures/test_travel_data.csv")
- 
+
 #     def test_load_units(self):
 #         unit_count = Unit.objects.all().count()
 #         self.assertEqual(unit_count, 3)
@@ -633,25 +633,25 @@ class TestFundDetailView(TestCase):
     fixtures = ["sample_data.json"]
 
     def test_fund_detail_denies_anonymous(self):
-        response = self.client.get("/fund/1/", follow=True)
+        response = self.client.get("/fund/1/2020/", follow=True)
         self.assertRedirects(
-            response, "/accounts/login/?next=/fund/1/", status_code=302
+            response, "/accounts/login/?next=/fund/1/2020/", status_code=302
         )
 
     def test_fund_detail_allows_full_access(self):
         self.client.login(username="doriswang", password="Staples50141")
-        response = self.client.get("/fund/1/")
+        response = self.client.get("/fund/1/2020/")
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "terra/fund.html")
 
     def test_fund_denies_non_lbs(self):
         self.client.login(username="tawopetu", password="Staples50141")
-        response = self.client.get("/fund/1/")
+        response = self.client.get("/fund/1/2020/")
         self.assertEqual(response.status_code, 403)
 
     def test_fund_detail_loads(self):
         self.client.login(username="aprigge", password="Staples50141")
-        response = self.client.get("/fund/1/")
+        response = self.client.get("/fund/1/2020/")
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "terra/fund.html")
 

--- a/terra/views.py
+++ b/terra/views.py
@@ -221,6 +221,7 @@ class FundDetailView(LoginRequiredMixin, UserPassesTestMixin, DetailView):
             fund=self.object, start_date=fy.start.date(), end_date=fy.end.date()
         )
         context["fiscalyear"] = "{} - {}".format(fy.start.year, fy.end.year)
+        context["fiscal_year_list"] = fiscal_year_list()
         return context
 
 


### PR DESCRIPTION
-changed fund urls so fiscal year is specified in the URL
-report changes data queried based on fiscal year specified in URL
-fund page has dropdown form to select desired year
-fund page defaults to current fiscal year
-export is for selected fy
-updated tests to new fund urls