### PR TITLE
TRRA-198: Fix to unit list view bug I created. 

### DIFF
--- a/terra/templates/terra/unit_list.html
+++ b/terra/templates/terra/unit_list.html
@@ -32,7 +32,7 @@
 		  {% if subunit.subunits.all %}
 		  <div class="list-group">
 			{% for subsubunit in subunit.subunits.all %}
-			  <a href="{% url 'unit_detail' pk=subunit.id year=current_fy %}" class="list-group-item list-group-item-action">
+			  <a href="{% url 'unit_detail' pk=subsubunit.id year=current_fy %}" class="list-group-item list-group-item-action">
 			    &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
 			    <b>{{subsubunit}}</b> - {{subsubunit.manager}}
 			  </a>


### PR DESCRIPTION
Changed `subunit.id` to `subsubunit.id` in link to unit detail view in line 35. Subsubunits has been linking to their parent unit instead.