### PR TITLE
Trra 140/fau treqs

### DIFF
--- a/terra/fixtures/sample_data.json
+++ b/terra/fixtures/sample_data.json
@@ -836,6 +836,16 @@
   }
 },
 {
+  "model": "terra.fund",
+  "pk": 3,
+  "fields": {
+    "account": "605000",
+    "cost_center": "LD",
+    "fund": "17084",
+    "manager": 5
+  }
+},
+{
   "model": "terra.travelrequest",
   "pk": 1,
   "fields": {
@@ -1213,7 +1223,7 @@
     "rate": null,
     "quantity": null,
     "total": "435.00000",
-    "fund": 1,
+    "fund": 3,
     "date_paid": "2019-06-30"
   }
 },
@@ -1226,7 +1236,7 @@
     "rate": null,
     "quantity": null,
     "total": "180.00000",
-    "fund": 1,
+    "fund": 3,
     "date_paid": "2020-01-01"
   }
 },

--- a/terra/reports.py
+++ b/terra/reports.py
@@ -270,14 +270,14 @@ def unit_report(unit, start_date=None, end_date=None):
 
 def get_treq_list(fund, start_date=None, end_date=None):
     start_date, end_date = check_dates(start_date, end_date)
-    rows = Funding.objects.filter(
+    funding_rows = Funding.objects.filter(
         fund=fund, treq__departure_date__gte=start_date, treq__return_date__lte=end_date
     ).values(travel=F("treq"))
 
-    rows2 = ActualExpense.objects.filter(
+    actual_expense_rows = ActualExpense.objects.filter(
         fund=fund, date_paid__gte=start_date, date_paid__lte=end_date
     ).values(travel=F("treq"))
-    treq_ids = set([e["travel"] for e in rows.union(rows2)])
+    treq_ids = set([e["travel"] for e in funding_rows.union(actual_expense_rows)])
     return treq_ids
 
 

--- a/terra/templates/terra/fund.html
+++ b/terra/templates/terra/fund.html
@@ -12,7 +12,10 @@
 </style>
 {% endblock %}
 
+
 {% block body %}
+
+
 
     <div class="row">
         <div class="col">
@@ -37,7 +40,9 @@
         </div>
     </div>
 
-    <table class="table">
+
+
+<table class="table">
         <thead class="thead-light">
             <tr>
                 <th colspan="2" scope="colgroup"></th>
@@ -58,22 +63,64 @@
                 <th scope="col" class="text-right">Total Spent</th>
             </tr>
         </thead>
-        <tbody>
-            {% for employee in employees %}
-            <tr>
-                <td><a href="/employee/{{employee.pk}}/{{fy_year}}/">{{employee.user.last_name}}, {{employee.user.first_name}}</a></td>
+    </table>
+
+    {% for employee in employees %}
+    <div id="accordion">
+    <div class="card">
+    <div class="card-header" id="headingOne">
+      <h5 class="mb-0">
+        <button class="btn btn-link" data-toggle="collapse" data-target="#collapseOne" aria-expanded="true" aria-controls="collapseOne">
+         
+        <table class="table">
+            
+        <tbody>    
+
+                <td>{{employee.user.last_name}}, {{employee.user.first_name}}</td>
                 <td>{{employee.get_type_display}}</td>
-                <td class="text-right">{{employee.profdev_requested|cap|safe}}</td>
-                <td class="text-right">{{employee.profdev_spent|cap|safe}}</td>
+                <td>{{employee.profdev_requested|cap|safe}}</td>
+                <td>{{employee.profdev_spent|cap|safe}}</td>
 
-                <td class="text-right">{{employee.admin_requested|currency}}</td>
-                <td class="text-right">{{employee.admin_spent|currency}}</td>
+                <td>{{employee.admin_requested|currency}}</td>
+                <td>{{employee.admin_spent|currency}}</td>
 
-                <td class="text-right">{{employee.total_requested|currency}}</td>
-                <td class="text-right">{{employee.total_spent|currency}}</td>
-            </tr>
-            {% endfor %}
+                <td>{{employee.total_requested|currency}}</td>
+                <td>{{employee.total_spent|currency}}</td>
         </tbody>
+    </table>
+        
+      </h5>
+    </div>
+</button>
+
+    <div id="collapseOne" class="collapse show" aria-labelledby="headingOne" data-parent="#accordion">
+      <div class="card-body">
+        <h5>Travel Requests using {{fund}}</h5>
+        <table class="table">
+            <thead>
+                <th colspan="1" scope="colgroup">Activity</th>
+                <th colspan="1" scope="colgroup">Administrative</th>
+                <th colspan="1" scope="colgroup">Amount Requested</th>
+                <th colspan="1" scope="colgroup">Amount Spent</th>
+            </thead> 
+            {% for treq in treq_funds %}
+                {% if treq.traveler.id == employee.id %}
+                    <tbody>
+
+                        <td>{{treq.activity}}</td>
+                        <td>{{treq.administrative}}</td>
+                        <td>{{treq.requested}}</td>
+                        <td>{{treq.spent}}</td>
+                    </tbody>
+                {% endif %}
+            {% endfor %}
+        </table>
+      </div>
+    </div>
+  </div>
+{% endfor %}
+
+    <table class="table">    
         <tfoot>
             <tr>
                 <th>Totals</th>

--- a/terra/templates/terra/fund.html
+++ b/terra/templates/terra/fund.html
@@ -12,10 +12,7 @@
 </style>
 {% endblock %}
 
-
 {% block body %}
-
-
 
     <div class="row">
         <div class="col">
@@ -40,9 +37,7 @@
         </div>
     </div>
 
-
-
-<table class="table">
+    <table class="table">
         <thead class="thead-light">
             <tr>
                 <th colspan="2" scope="colgroup"></th>
@@ -52,7 +47,7 @@
             </tr>
             <tr>
                 <th scope="col">Employee</th>
-                <th scope="col">Type</th>
+                <th scope="col">Activity</th>
                 <th scope="col" class="text-right">Amount Requested</th>
                 <th scope="col" class="text-right">Amount Spent</th>
                 
@@ -63,64 +58,38 @@
                 <th scope="col" class="text-right">Total Spent</th>
             </tr>
         </thead>
-    </table>
+        <tbody>
+        {% for employee in employees %}
+            <tr>
+                <th>{{employee.user.last_name}}, {{employee.user.first_name}} ({{employee.get_type_display}}) Total</th>
+                <th></th>
+                <th class="text-right">{{employee.profdev_requested|cap|safe}}</th>
+                <th class="text-right">{{employee.profdev_spent|cap|safe}}</th>
 
-    {% for employee in employees %}
-    <div id="accordion">
-    <div class="card">
-    <div class="card-header" id="headingOne">
-      <h5 class="mb-0">
-        <button class="btn btn-link" data-toggle="collapse" data-target="#collapseOne" aria-expanded="true" aria-controls="collapseOne">
-         
-        <table class="table">
-            
-        <tbody>    
+                <th class="text-right">{{employee.admin_requested|currency}}</th>
+                <th class="text-right">{{employee.admin_spent|currency}}</th>
 
-                <td>{{employee.user.last_name}}, {{employee.user.first_name}}</td>
-                <td>{{employee.get_type_display}}</td>
-                <td>{{employee.profdev_requested|cap|safe}}</td>
-                <td>{{employee.profdev_spent|cap|safe}}</td>
-
-                <td>{{employee.admin_requested|currency}}</td>
-                <td>{{employee.admin_spent|currency}}</td>
-
-                <td>{{employee.total_requested|currency}}</td>
-                <td>{{employee.total_spent|currency}}</td>
-        </tbody>
-    </table>
-        
-      </h5>
-    </div>
-</button>
-
-    <div id="collapseOne" class="collapse show" aria-labelledby="headingOne" data-parent="#accordion">
-      <div class="card-body">
-        <h5>Travel Requests using {{fund}}</h5>
-        <table class="table">
-            <thead>
-                <th colspan="1" scope="colgroup">Activity</th>
-                <th colspan="1" scope="colgroup">Administrative</th>
-                <th colspan="1" scope="colgroup">Amount Requested</th>
-                <th colspan="1" scope="colgroup">Amount Spent</th>
-            </thead> 
+                <th class="text-right">{{employee.total_requested|currency}}</th>
+                <th class="text-right">{{employee.total_spent|currency}}</th>
+            </tr>
             {% for treq in treq_funds %}
                 {% if treq.traveler.id == employee.id %}
-                    <tbody>
-
-                        <td>{{treq.activity}}</td>
-                        <td>{{treq.administrative}}</td>
-                        <td>{{treq.requested}}</td>
-                        <td>{{treq.spent}}</td>
-                    </tbody>
+                    <tr>
+                        <td><a href="/employee/{{employee.pk}}/{{fy_year}}/">{{employee.user.last_name}}, {{employee.user.first_name}}</a></td>
+                        <td><a href='/treq/{{treq.pk}}/'>{{treq.activity}}</a></td>
+                        
+                        <td class="text-right">{{treq.profdev_requested|currency}}</td>
+                        <td class="text-right">{{treq.profdev_spent|currency}}</td>
+                        
+                        <td class="text-right">{{treq.admin_requested|currency}}</td>
+                        <td class="text-right">{{treq.admin_spent|currency}}</td>
+                        <td class="text-right"></td>
+                        <td class="text-right"></td>
+                    </tr>
                 {% endif %}
             {% endfor %}
-        </table>
-      </div>
-    </div>
-  </div>
-{% endfor %}
-
-    <table class="table">    
+        {% endfor %}
+            </tbody>
         <tfoot>
             <tr>
                 <th>Totals</th>
@@ -139,4 +108,3 @@
 
 
 {% endblock %}
-

--- a/terra/tests.py
+++ b/terra/tests.py
@@ -594,9 +594,9 @@ class FundReportsTestCase(TestCase):
             "admin_requested": Decimal("1050"),
             "admin_spent": Decimal("0"),
             "profdev_requested": Decimal("5500.00000"),
-            "profdev_spent": Decimal("4345"),
+            "profdev_spent": Decimal("4165"),
             "total_requested": Decimal("6550.00000"),
-            "total_spent": Decimal("4345"),
+            "total_spent": Decimal("4165"),
         }
         fund = Fund.objects.get(pk=1)
         employees, totals = reports.fund_report(fund)

--- a/terra/tests.py
+++ b/terra/tests.py
@@ -312,8 +312,13 @@ class TestTreqDetailView(TestCase):
 
     def test_treq_detail_allows_full_access(self):
         self.client.login(username="doriswang", password="Staples50141")
-        response = self.client.get("/unit/1/2020/")
-        self.assertTemplateUsed(response, "terra/unit.html")
+        response = self.client.get("/treq/2/")
+        self.assertTemplateUsed(response, "terra/treq.html")
+        self.assertEqual(response.status_code, 200)
+
+    def test_treq_detail_allows_fund_manager(self):
+        self.client.login(username="tawopetu", password="Staples50141")
+        response = self.client.get("/treq/5/")
         self.assertEqual(response.status_code, 200)
 
     def test_treq_detail_loads(self):
@@ -588,6 +593,25 @@ class FundReportsTestCase(TestCase):
         for eid in eids:
             with self.subTest(eid=eid):
                 self.assertTrue(eid in expected)
+
+    def test_get_treq_list(self):
+        fund = Fund.objects.get(pk=2)
+        treqs = reports.get_treq_list(fund, self.start_date, self.end_date)
+        expected = [1, 7]
+        for treq in treqs:
+            self.assertTrue(treq in expected)
+
+    def test_get_individual_data_for_treq(self):
+        fund = Fund.objects.get(pk=3)
+        treq_ids = reports.get_treq_list(fund, self.start_date, self.end_date)
+        actual = reports.get_individual_data_for_treq(
+            treq_ids, fund, self.start_date, self.end_date
+        )
+        for treq in actual:
+            self.assertEqual(treq.profdev_requested, Decimal(0))
+            self.assertEqual(treq.profdev_spent, Decimal(180))
+            self.assertEqual(treq.admin_requested, Decimal(0))
+            self.assertEqual(treq.admin_spent, Decimal(0))
 
     def test_fund_report(self):
         expected = {

--- a/terra/views.py
+++ b/terra/views.py
@@ -97,15 +97,10 @@ class TreqDetailView(LoginRequiredMixin, UserPassesTestMixin, DetailView):
 
         eligible_users = [treq.traveler, treq.traveler.supervisor]
         eligible_users.extend(treq.traveler.unit.super_managers())
-
         for funding in treq.funding_set.all():
-            manager = funding.fund.manager
-            if manager is not None:
-                eligible_users.append(manager)
+            eligible_users.append(funding.fund.manager)
         for actualexpense in treq.actualexpense_set.all():
-            manager = actualexpense.fund.manager
-            if manager is not None:
-                eligible_users.append(manager)
+            eligible_users.append(actualexpense.fund.manager)
 
         return user.employee in eligible_users or user.employee.has_full_report_access()
 
@@ -294,19 +289,6 @@ class FundExportView(FundDetailView):
             ]
         )
         for e in context["employees"]:
-            for t in context["treq_funds"]:
-                if e.id == t.traveler.id:
-                    writer.writerow(
-                        [
-                            f"{e.user.last_name}, {e.user.first_name}",
-                            "",
-                            t.activity,
-                            t.profdev_requested,
-                            t.profdev_spent,
-                            t.admin_requested,
-                            t.admin_spent,
-                        ]
-                    )
             writer.writerow(
                 [
                     f"{e.user.last_name}, {e.user.first_name} Total",
@@ -320,6 +302,20 @@ class FundExportView(FundDetailView):
                     e.total_spent,
                 ]
             )
+            for t in context["treq_funds"]:
+                if e.id == t.traveler.id:
+                    writer.writerow(
+                        [
+                            f"{e.user.last_name}, {e.user.first_name}",
+                            "",
+                            t.activity,
+                            t.profdev_requested,
+                            t.profdev_spent,
+                            t.admin_requested,
+                            t.admin_spent,
+                        ]
+                    )
+
         writer.writerow(
             [
                 "Totals",

--- a/terra/views.py
+++ b/terra/views.py
@@ -6,7 +6,7 @@ from django.views.generic import View, DetailView
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from django.contrib.auth.decorators import login_required
 
-from .models import TravelRequest, Unit, Fund, Employee, ActualExpense
+from .models import TravelRequest, Unit, Fund, Employee, Fund, Funding, ActualExpense
 from .reports import (
     unit_report,
     fund_report,
@@ -15,6 +15,8 @@ from .reports import (
     employee_total_report,
     get_subunits_and_employees,
     get_individual_data_treq,
+    get_treq_list,
+    get_individual_data_for_treq,
 )
 from .utils import (
     current_fiscal_year_object,
@@ -239,11 +241,23 @@ class FundDetailView(LoginRequiredMixin, UserPassesTestMixin, DetailView):
         context = super().get_context_data(*args, **kwargs)
         fy = fiscal_year(fiscal_year=self.kwargs["year"])
         context["fy"] = self.kwargs["year"]
+
         context["employees"], context["totals"] = fund_report(
             fund=self.object, start_date=fy.start.date(), end_date=fy.end.date()
         )
         context["fiscalyear"] = "{} - {}".format(fy.start.year, fy.end.year)
         context["fiscal_year_list"] = fiscal_year_list()
+        treq_ids = get_treq_list(
+            fund=self.object, start_date=fy.start.date(), end_date=fy.end.date()
+        )
+        context["treq_ids"] = treq_ids
+        context["treq_funds"] = get_individual_data_for_treq(
+            treq_ids=treq_ids,
+            fund=self.object,
+            start_date=fy.start.date(),
+            end_date=fy.end.date(),
+        )
+
         return context
 
 


### PR DESCRIPTION
TRRA-140 changes the FAU report to be list travel requests and employee aggregates for each FAU. Eventually fund managers will be able to click into treq detail pages for non-employees from this report.
-Added new fund to sample data so that a non-manager approves expenses for an employee
-Added queries to calculate type of amount spent per treq per fund
-Changed layout of FAU report template to list all employee aggregate totals then each treq the FAU was used for
-Added fund managers to list of eligible users in treq detail view
-Added tests
-Updated export to match template FAU report