### PR TITLE
TRRA-213: Removed imported but unused items.

### DIFF
--- a/terra/management/commands/load_employees.py
+++ b/terra/management/commands/load_employees.py
@@ -1,29 +1,30 @@
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 from django.contrib.auth.models import User
 from django.core.exceptions import ObjectDoesNotExist
 from terra.models import Employee, Unit, EMPLOYEE_TYPES
 
 import csv
 
+
 def create_employees(self, employee_file):
     """
     Does initial creation of Employees, and their underlying Users.
     """
-    self.stdout.write(f'Parsing {employee_file}')
+    self.stdout.write(f"Parsing {employee_file}")
     # Windows-derived CSV has leading BOM, so specify utf-8-sig, not utf-8
-    with open(employee_file, encoding='utf-8-sig', newline='') as csvfile:
-        reader = csv.DictReader(csvfile, dialect='excel')
+    with open(employee_file, encoding="utf-8-sig", newline="") as csvfile:
+        reader = csv.DictReader(csvfile, dialect="excel")
         # Field names from CSV, for reference:
         # ['department_code', 'employee_name', 'employee_id', 'ucla_id', 'email', job_code', 'job_code_desc', 'job_class_description', 'supervisor', 'department', 'aul_ul']
         for row in reader:
             # Get relevant data from CSV
-            department = row['department']
-            email = row['email']
-            employee_name = row['employee_name']
-            ucla_id = row['ucla_id']
-            staff_type = row['staff_type']
+            department = row["department"]
+            email = row["email"]
+            employee_name = row["employee_name"]
+            ucla_id = row["ucla_id"]
+            staff_type = row["staff_type"]
 
-            self.stdout.write(f'\tProcessing {employee_name}...')
+            self.stdout.write(f"\tProcessing {employee_name}...")
 
             # User & Employee
             user = _get_user(employee_name, email)
@@ -35,7 +36,7 @@ def create_employees(self, employee_file):
 def _get_user(employee_name, email):
     # Employees are based on Users, so create user first.
     # Use the email name as username for now, with unusable password.
-    username = email.split('@')[0]
+    username = email.split("@")[0]
     # Users might already exist, via small initial load
     user, created = User.objects.get_or_create(username=username, email=email)
     # Add first/last name to the user
@@ -46,8 +47,11 @@ def _get_user(employee_name, email):
 
 def _get_employee(user, ucla_id, unit, staff_type):
     staff_type = _get_employee_type_key(staff_type)
-    employee, created = Employee.objects.get_or_create(user=user, uid=ucla_id, unit=unit, type=staff_type)
+    employee, created = Employee.objects.get_or_create(
+        user=user, uid=ucla_id, unit=unit, type=staff_type
+    )
     return employee
+
 
 def _get_employee_type_key(value):
     # EMPLOYEE_TYPES is tuple of tuples; we need key matching value in 1.
@@ -55,16 +59,17 @@ def _get_employee_type_key(value):
     d = dict(EMPLOYEE_TYPES)
     return list(d.keys())[list(d.values()).index(value)]
 
+
 def add_supervisors(self, employee_file):
     """
     Adds supervisors to employees.
     """
-    self.stdout.write(f'\nAdding supervisors...')
-    with open(employee_file, encoding='utf-8-sig', newline='') as csvfile:
-        reader = csv.DictReader(csvfile, dialect='excel')
+    self.stdout.write(f"\nAdding supervisors...")
+    with open(employee_file, encoding="utf-8-sig", newline="") as csvfile:
+        reader = csv.DictReader(csvfile, dialect="excel")
         for row in reader:
-            employee_name = row['employee_name']
-            supervisor_name = row['supervisor']
+            employee_name = row["employee_name"]
+            supervisor_name = row["supervisor"]
             if supervisor_name:
                 self.stdout.write(f"Adding {supervisor_name} to {employee_name}")
                 supervisor = find_employee_by_name(self, supervisor_name)
@@ -72,7 +77,8 @@ def add_supervisors(self, employee_file):
                 employee.supervisor = supervisor
                 employee.save()
             else:
-                self.stderr.write(f'\tNo supervisor found for {employee_name}')
+                self.stderr.write(f"\tNo supervisor found for {employee_name}")
+
 
 def find_employee_by_name(self, employee_name):
     """
@@ -80,25 +86,31 @@ def find_employee_by_name(self, employee_name):
     """
     last_name, first_name = _split_name(employee_name)
     try:
-        employee = Employee.objects.get(user=User.objects.get(last_name__exact=last_name, first_name__exact=first_name))
+        employee = Employee.objects.get(
+            user=User.objects.get(
+                last_name__exact=last_name, first_name__exact=first_name
+            )
+        )
         return employee
     except ObjectDoesNotExist:
         self.stderr.write(f"\tERROR: {employee_name} not found")
+
 
 def _split_name(employee_name):
     """
     Utility method for splitting 'Last, First' into 'Last' and 'First'.
     """
-    last_name, first_name = [word.strip() for word in employee_name.split(',')]
+    last_name, first_name = [word.strip() for word in employee_name.split(",")]
     return (last_name, first_name)
 
+
 class Command(BaseCommand):
-    help = 'Load employees from CSV into database'
+    help = "Load employees from CSV into database"
 
     def add_arguments(self, parser):
-        parser.add_argument('employee_file')
+        parser.add_argument("employee_file")
 
     def handle(self, *args, **options):
-        employee_file = options['employee_file']
+        employee_file = options["employee_file"]
         create_employees(self, employee_file)
         add_supervisors(self, employee_file)

--- a/terra/management/commands/load_employees.py
+++ b/terra/management/commands/load_employees.py
@@ -64,7 +64,7 @@ def add_supervisors(self, employee_file):
     """
     Adds supervisors to employees.
     """
-    self.stdout.write(f"\nAdding supervisors...")
+    self.stdout.write("\nAdding supervisors...")
     with open(employee_file, encoding="utf-8-sig", newline="") as csvfile:
         reader = csv.DictReader(csvfile, dialect="excel")
         for row in reader:

--- a/terra/management/commands/load_travel_data.py
+++ b/terra/management/commands/load_travel_data.py
@@ -1,4 +1,4 @@
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 from django.contrib.auth.models import User
 from django.core.exceptions import ObjectDoesNotExist
 from terra.models import (

--- a/terra/management/commands/load_unit_heads.py
+++ b/terra/management/commands/load_unit_heads.py
@@ -1,21 +1,22 @@
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 from django.contrib.auth.models import User
 from django.core.exceptions import ObjectDoesNotExist
 from terra.models import Employee, Unit
 
 import csv
 
+
 def add_unit_heads(self, unit_file):
     """
     Does initial creation of Units.
     """
-    self.stdout.write(f'Parsing {unit_file}')
+    self.stdout.write(f"Parsing {unit_file}")
     # Windows-derived CSV has leading BOM, so specify utf-8-sig, not utf-8
-    with open(unit_file, encoding='utf-8-sig', newline='') as csvfile:
-        reader = csv.DictReader(csvfile, dialect='excel')
+    with open(unit_file, encoding="utf-8-sig", newline="") as csvfile:
+        reader = csv.DictReader(csvfile, dialect="excel")
         for row in reader:
-            unit_name = row['unit']
-            unit_head = row['unit_head']
+            unit_name = row["unit"]
+            unit_head = row["unit_head"]
             unit = Unit.objects.get(name__exact=unit_name)
             manager = find_employee_by_name(self, unit_head)
             unit.manager = manager
@@ -28,24 +29,30 @@ def find_employee_by_name(self, employee_name):
     """
     last_name, first_name = _split_name(employee_name)
     try:
-        employee = Employee.objects.get(user=User.objects.get(last_name__exact=last_name, first_name__exact=first_name))
+        employee = Employee.objects.get(
+            user=User.objects.get(
+                last_name__exact=last_name, first_name__exact=first_name
+            )
+        )
         return employee
     except ObjectDoesNotExist:
         self.stderr.write(f"\tERROR: {employee_name} not found")
+
 
 def _split_name(employee_name):
     """
     Utility method for splitting 'Last, First' into 'Last' and 'First'.
     """
-    last_name, first_name = [word.strip() for word in employee_name.split(',')]
+    last_name, first_name = [word.strip() for word in employee_name.split(",")]
     return (last_name, first_name)
 
+
 class Command(BaseCommand):
-    help = 'Add unit heads from CSV to units in database.'
+    help = "Add unit heads from CSV to units in database."
 
     def add_arguments(self, parser):
-        parser.add_argument('unit_file')
+        parser.add_argument("unit_file")
 
     def handle(self, *args, **options):
-        unit_file = options['unit_file']
+        unit_file = options["unit_file"]
         add_unit_heads(self, unit_file)

--- a/terra/management/commands/load_units.py
+++ b/terra/management/commands/load_units.py
@@ -1,21 +1,22 @@
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 from terra.models import Unit
 
 import csv
+
 
 def create_units(self, unit_file):
     """
     Does initial creation of Units.
     """
-    self.stdout.write(f'Parsing {unit_file}')
+    self.stdout.write(f"Parsing {unit_file}")
     # Windows-derived CSV has leading BOM, so specify utf-8-sig, not utf-8
-    with open(unit_file, encoding='utf-8-sig', newline='') as csvfile:
-        reader = csv.DictReader(csvfile, dialect='excel')
+    with open(unit_file, encoding="utf-8-sig", newline="") as csvfile:
+        reader = csv.DictReader(csvfile, dialect="excel")
         for row in reader:
             unit_name = row["unit"]
             unit_type = row["unit_type"]
             unit_parent = row["parent"]
-            self.stdout.write(f'Adding {unit_name}...')
+            self.stdout.write(f"Adding {unit_name}...")
 
             unit = Unit.objects.create(name=unit_name, type=unit_type)
             # These get read from CSV as strings...
@@ -26,11 +27,11 @@ def create_units(self, unit_file):
 
 
 class Command(BaseCommand):
-    help = 'Load units from CSV into database'
+    help = "Load units from CSV into database"
 
     def add_arguments(self, parser):
-        parser.add_argument('unit_file')
+        parser.add_argument("unit_file")
 
     def handle(self, *args, **options):
-        unit_file = options['unit_file']
+        unit_file = options["unit_file"]
         create_units(self, unit_file)

--- a/terra/management/commands/test.py
+++ b/terra/management/commands/test.py
@@ -1,8 +1,8 @@
-from django.core.management.base import BaseCommand, CommandError
 from django.core.management.commands import test
 
 import os
 import MySQLdb
+
 
 class Command(test.Command):
     help = "Overrides built-in test command to set MySQL permissions on test database."

--- a/terra/reports.py
+++ b/terra/reports.py
@@ -7,26 +7,13 @@ from django.db.models import (
     OuterRef,
     Subquery,
     DecimalField,
-    ExpressionWrapper,
     IntegerField,
 )
-from django.db.models.functions import Coalesce, ExtractDay
+from django.db.models.functions import Coalesce
 
 
-from .models import (
-    TravelRequest,
-    Employee,
-    Funding,
-    ActualExpense,
-    Fund,
-    EMPLOYEE_TYPES,
-)
-from .utils import (
-    fiscal_year_bookends,
-    current_fiscal_year_int,
-    profdev_spending_cap,
-    profdev_days_cap,
-)
+from .models import TravelRequest, Employee, Funding, ActualExpense
+from .utils import fiscal_year_bookends, profdev_spending_cap, profdev_days_cap
 
 
 def check_dates(start_date, end_date):

--- a/terra/templatetags/terra_extras.py
+++ b/terra/templatetags/terra_extras.py
@@ -6,11 +6,6 @@ from terra.utils import (
     profdev_days_cap,
     profdev_days_warning,
 )
-from datetime import date
-from django.conf import settings
-
-import fiscalyear as FY
-import locale
 
 register = template.Library()
 

--- a/terra/tests.py
+++ b/terra/tests.py
@@ -1,11 +1,8 @@
 from datetime import date
 from decimal import Decimal
-import json
 
 from django.test import TestCase
 from django.contrib.auth.models import User
-from django.core.management import call_command
-from django.core.serializers.json import DjangoJSONEncoder
 
 
 from fiscalyear import FiscalYear
@@ -276,7 +273,7 @@ class TestEmpoyeeDetailView(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "terra/employee.html")
 
-    def test_employee_detail_loads(self):
+    def test_second_employee_detail_loads(self):
         self.client.login(username="aprigge", password="Staples50141")
         response = self.client.get("/employee/2/2019-2019/")
         self.assertEqual(response.status_code, 200)
@@ -1047,7 +1044,7 @@ class EmployeeSubtotalTestCase(TestCase):
         for employee in actual:
             for key, value in actual[employee].items():
                 with self.subTest(key=key, value=value):
-                    self.assertEqual(actual[employee][key], actual[employee][key])
+                    self.assertEqual(actual[employee][key], expected[employee][key])
 
 
 class ActualExpenseTestCase(TestCase):

--- a/terra/views.py
+++ b/terra/views.py
@@ -2,30 +2,22 @@ import csv
 from django.http import HttpResponseRedirect, HttpResponse
 from django.urls import reverse
 from django.views.generic.list import ListView
-from django.views.generic import View, DetailView
+from django.views.generic import DetailView
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from django.contrib.auth.decorators import login_required
 
-from .models import TravelRequest, Unit, Fund, Employee, Fund, Funding, ActualExpense
+from .models import TravelRequest, Unit, Employee, Fund, ActualExpense
 from .reports import (
     unit_report,
     fund_report,
     merge_data_type,
-    get_type_and_employees,
     employee_total_report,
     get_subunits_and_employees,
     get_individual_data_treq,
     get_treq_list,
     get_individual_data_for_treq,
 )
-from .utils import (
-    current_fiscal_year_object,
-    current_fiscal_year,
-    fiscal_year_bookends,
-    fiscal_year,
-    current_fiscal_year_int,
-    fiscal_year_list,
-)
+from .utils import fiscal_year, current_fiscal_year_int, fiscal_year_list
 
 
 @login_required
@@ -102,7 +94,6 @@ class EmployeeDetailView(LoginRequiredMixin, UserPassesTestMixin, DetailView):
 class EmployeeDetailExportView(EmployeeDetailView):
     def render_to_response(self, context, **response_kwargs):
         employee = context.get("employee")
-        fiscal_year_list = context.get("fiscal_year_list")
         report = context.get("report")
         actualexpenses_fy = context.get("actualexpenses_fy")
         fy_start = context.get("fy_start")
@@ -270,10 +261,8 @@ class UnitDetailView(LoginRequiredMixin, UserPassesTestMixin, DetailView):
 class UnitExportView(UnitDetailView):
     def render_to_response(self, context, **response_kwargs):
         unit = context.get("unit")
-        team = unit.all_employees()
         start_fy = fiscal_year(fiscal_year=self.kwargs["start_year"])
         end_fy = fiscal_year(fiscal_year=self.kwargs["end_year"])
-        totals = context.get("totals")
         response = HttpResponse(content_type="text/csv")
         response[
             "Content-Disposition"
@@ -766,10 +755,8 @@ class UnitOrgExportView(UnitDetailView):
 
     def render_to_response(self, context, **response_kwargs):
         unit = context.get("unit")
-        team = unit.all_employees()
         start_fy = fiscal_year(fiscal_year=self.kwargs["start_year"])
         end_fy = fiscal_year(fiscal_year=self.kwargs["end_year"])
-        totals = context.get("totals")
         response = HttpResponse(content_type="text/csv")
         response[
             "Content-Disposition"


### PR DESCRIPTION
Removed various unused imports and several defined, but unused variables.
These are the remaining warnings. 

`terra/management/commands/load_travel_data.py:77:17 local variable 'funding' is assigned to but never used`
`terra/management/commands/load_travel_data.py:83:17 local variable 'act_expense' is assigned to but never used`
`terra/management/commands/load_employees.py:32:13 local variable 'employee' is assigned to but never used`
`terra/management/commands/load_employees.py:62:23 f-string is missing placeholders`

The first and third look like incorrect warnings to me as the variables are actually used later in the code. I am not sure if it makes sense to change the third warning. The last warning also seems like an unnecessary change.  Pease let me know your thoughts. Thanks
(The linter made some formatting changes as well.)