### PR TITLE
TRRA 217/uid actual expense report

### DIFF
--- a/terra/templates/terra/actual_expense_report.html
+++ b/terra/templates/terra/actual_expense_report.html
@@ -41,6 +41,7 @@
     <thead class="thead-light">
       <th class="text">AUL</th>
       <th class="text">Department</th>
+      <th class="text">UID</th>
       <th class="text">Employee</th>
       <th class="text">Type</th>
       <th class="text">Activity</th>
@@ -65,6 +66,7 @@
                       <td></td>
                     {% endif %}
                     <td class="text">{{actualexpense.treq.traveler.unit}}</td>
+                    <td class="text">{{actualexpense.treq.traveler.uid}}</td>
                     <td><a href="/employee/{{actualexpense.treq.traveler.pk}}/{{fy_year}}-{{fy_year}}/">{{actualexpense.treq.traveler}}</a></td>
                     <td class="text">{{actualexpense.treq.traveler.get_type_display}}</td>
                     <td><a href="/treq/{{actualexpense.treq.pk}}/">{{actualexpense.treq.activity}}</a></td>
@@ -83,6 +85,7 @@
                 {% for  employee in subunit.employees.values %}
                   {% if employee == e and employee.data.total_spent != 0%}
                     <tr>
+                      <td class="text"></td>
                       <td class="text"></td>
                       <td class="text"></td>
                       <th class="text">{{employee}} ({{employee.get_type_display}}) Total</th>
@@ -107,6 +110,7 @@
             <tr>
             <th>Library Total</th>
                 <th></th>
+                <th class="text-right"></th>
                 <th class="text-right"></th>
                 <th class="text-right"></th>
                 <th class="text-right"></th>

--- a/terra/tests.py
+++ b/terra/tests.py
@@ -637,7 +637,7 @@ class FundReportsTestCase(TestCase):
             "total_spent": Decimal("4165"),
         }
         fund = Fund.objects.get(pk=1)
-        employees, totals = reports.fund_report(fund)
+        employees, totals = reports.fund_report(fund, self.start_date, self.end_date)
         self.assertEqual(len(employees), 3)
         for key, value in expected.items():
             with self.subTest(key=key, value=value):

--- a/terra/views.py
+++ b/terra/views.py
@@ -654,6 +654,7 @@ class ActualExpenseExportView(ActualExpenseListView):
             [
                 "AUL",
                 "Department",
+                "UID",
                 "Employee",
                 "Type",
                 "Activity",
@@ -677,6 +678,7 @@ class ActualExpenseExportView(ActualExpenseListView):
                                 [
                                     v["subunit"].manager,
                                     actualexpense.treq.traveler.unit,
+                                    actualexpense.treq.traveler.uid,
                                     actualexpense.treq.traveler,
                                     actualexpense.treq.traveler.get_type_display(),
                                     actualexpense.treq.activity,
@@ -694,6 +696,7 @@ class ActualExpenseExportView(ActualExpenseListView):
                                 [
                                     "",
                                     actualexpense.treq.traveler.unit,
+                                    actualexpense.treq.traveler.uid,
                                     actualexpense.treq.traveler,
                                     actualexpense.treq.traveler.get_type_display(),
                                     actualexpense.treq.activity,
@@ -714,6 +717,7 @@ class ActualExpenseExportView(ActualExpenseListView):
                                 [
                                     "",
                                     "",
+                                    "",
                                     f"{employee} ({employee.get_type_display()}) Total",
                                     "",
                                     "",
@@ -731,6 +735,7 @@ class ActualExpenseExportView(ActualExpenseListView):
         writer.writerow(
             [
                 "Library Total",
+                "",
                 "",
                 "",
                 "",


### PR DESCRIPTION
-Add UID to Actual Expense View and CSV export
-Updated a fund report test to pass in 2020 FY start and end dates specifically (hadn't noticed this was missing as it defaulted to current FY)