### PR TITLE
Fix CSRF_TRUSTED_ORIGINS

### DIFF
--- a/.docker-compose_django.env
+++ b/.docker-compose_django.env
@@ -24,7 +24,7 @@ DJANGO_ALLOWED_HOSTS=localhost,127.0.0.1,[::1]
 
 # Django 4 may require this, at least in our deployment environment.
 # Comma separated list (if multiple) of additional trusted hosts
-DJANGO_CSRF_TRUSTED_ORIGINS=https://go.library.ucla.edu
+DJANGO_CSRF_TRUSTED_ORIGINS=https://terra.library.ucla.edu
 
 # For createsuperuser
 DJANGO_SUPERUSER_USERNAME=admin

--- a/charts/prod-terra-values.yaml
+++ b/charts/prod-terra-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/terra
-  tag: v1.1.0
+  tag: v1.1.1
   pullPolicy: Always
 
 nameOverride: ""

--- a/charts/prod-terra-values.yaml
+++ b/charts/prod-terra-values.yaml
@@ -40,7 +40,7 @@ django:
     allowed_hosts:
       - terra.library.ucla.edu
     csrf_trusted_origins:
-      - terra.library.ucla.edu
+      - https://terra.library.ucla.edu
     db_backend: "django.db.backends.postgresql_psycopg2"
     db_name: "terraprod"
     db_user: "terraprod"


### PR DESCRIPTION
Fixes incorrect `csrf_trusted_origins` in Helm chart values - must be a URL!  Also fixed different, irrelevant mistake with the value in local docker-compose environment file.

Bumps version to `v1.1.1` for deployment.
