### PR TITLE
SYS-1669: Upgrade image and packages

### DIFF
--- a/.docker-compose_django.env
+++ b/.docker-compose_django.env
@@ -10,7 +10,7 @@
 DJANGO_RUN_ENV=dev
 
 # 'Secret' key for dev only
-DJANGO_SECRET_KEY="-2^j5b_8!l&$m!!k)^xfwe0gre0c^lifay3%_lp9(ul0tl$m%#"
+DJANGO_SECRET_KEY='-2^j5b_8!l&$m!!k)^xfwe0gre0c^lifay3%_lp9(ul0tl$m%#'
 
 # For dev only
 DJANGO_DEBUG=True

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-bullseye
+FROM python:3.12-slim-bookworm
 
 RUN apt-get update
 

--- a/README.md
+++ b/README.md
@@ -5,45 +5,6 @@ Travel & Entertainment Requests & Reports Application
 
 ## Developer Setup
 
-### Local
-
-1. Install Python 3.7
-	- I recommend following this guide: https://docs.python-guide.org/
-2. Open your terminal and open your projects directory
-
-		$ cd /some/path/where/you/put/code
-
-3. Clone this repo
-	1. with SSH:
-
-			$ git clone git@github.com:UCLALibrary/terra.git
-
-	2. with HTTPS:
-
-			$ git clone https://github.com/UCLALibrary/terra.git
-
-4. Switch to the repo root
-
-		$ cd terra
-
-5. Create a Python virtual environment and activate it
-
-		$ python3 -m venv ENV
-		$ source ENV/bin/activate
-
-6. Update pip and install the Python packages
-
-		$ pip install --upgrade pip
-		$ pip install -r requirements.txt
-
-7. Install the pre-commit hook
-
-		$ pre-commit install
-
-8. Create the database tables
-
-		$ python manage.py migrate
-
 ### Docker
 
 1. Install docker and docker-compose.

--- a/charts/prod-terra-values.yaml
+++ b/charts/prod-terra-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/terra
-  tag: v1.1.3
+  tag: v1.1.4
   pullPolicy: Always
 
 nameOverride: ""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.1"
 services:
   django:
     # Always build, if using this compose file

--- a/docker-compose_REMOTE.yml
+++ b/docker-compose_REMOTE.yml
@@ -1,4 +1,3 @@
-version: "3.1"
 services:
   django:
     build: .

--- a/docker_scripts/entrypoint.sh
+++ b/docker_scripts/entrypoint.sh
@@ -16,13 +16,13 @@ done
 python ./manage.py migrate
 
 if [ "$DJANGO_RUN_ENV" = "dev" ]; then
-  # Create default superuser for dev environment, using django env vars.
-  # Logs will show error if this exists, which is OK.
-  python manage.py createsuperuser --no-input
-
   # Load fixtures, only in dev environment.
   echo "Loading sample data set..."
   python ./manage.py loaddata sample_data
+
+  # Create default superuser for dev environment, using django env vars.
+  # Logs will show error if this exists, which is OK.
+  python manage.py createsuperuser --no-input
 fi
 
 # Build static files directory, starting fresh each time

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,7 @@
-Django==4.2.11
+Django==4.2.16
 psycopg2==2.9.7
 django-crispy-forms==2.1
 crispy-bootstrap5==2023.10
 fiscalyear==0.4.0
 whitenoise==6.5.0
-gunicorn==21.2.0
-# Used for legacy development, could be removed later per ak.
-black
-pre-commit
-pyflakes
+gunicorn==23.0.0


### PR DESCRIPTION
Implements [SYS-1669](https://uclalibrary.atlassian.net/browse/SYS-1669). Bumps version to `v1.1.4` for deployment. This application currently has no release notes template file.

This PR makes various internal changes, without affecting functionality:
* Base image now uses Debian 12 (bookworm) and Python 3.12
* Django updated to latest 4.2.x (4.2.16) security patch
* gunicorn updated to latest (23.0.0), mainly for security fixes
* Removed obsolete version declaration from `docker-compose.yml` files
* Removed obsolete non-Docker build info from `README.md`

I also found I had to change from double-quotes to single-quotes around the value of our local `DJANGO_SECRET_KEY`, because the newer `docker compose` we're using was interpreting the embedded characters `$m` in it as a environment variable called `m` and giving a warning about not finding it...

### Testing
Please confirm the new image builds cleanly for you.  I reviewed all logs and found no errors, no explicit warnings, just a few typical messages from `debconf` about no "dialog frontend", which I routinely see when building these images.

Confirm the updated system starts cleanly and all 81 tests pass with `docker compose exec django python manage.py test`

Confirm you can log into http://127.0.0.1:8000/admin/ (as `admin / admin`).

I also confirmed that the `gunicorn` upgrade doesn't break anything (as far as I can tell), by temporarily setting `DJANGO_RUN_ENV=prod` in `.docker-compose_django.env`, starting the application and viewing the logs.



[SYS-1669]: https://uclalibrary.atlassian.net/browse/SYS-1669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ