### PR TITLE
SYS-1751: Update Django to 4.2.19 to patch security issues and add release notes

### DIFF
--- a/charts/prod-terra-values.yaml
+++ b/charts/prod-terra-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/terra
-  tag: v1.1.4
+  tag: v1.1.5
   pullPolicy: Always
 
 nameOverride: ""

--- a/proj/urls.py
+++ b/proj/urls.py
@@ -20,6 +20,7 @@ from terra.views import (
     UnitOrgExportView,
     EmployeeDetailExportView,
     home,
+    release_notes
 )
 
 urlpatterns = [
@@ -145,4 +146,5 @@ urlpatterns = [
         name="actual_expense_report_csv",
     ),
     path("", home, name="home"),
+    path("release_notes/", release_notes, name="release_notes")
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==4.2.16
+Django==4.2.19
 psycopg2==2.9.7
 django-crispy-forms==2.1
 crispy-bootstrap5==2023.10

--- a/terra/templates/terra/release_notes.html
+++ b/terra/templates/terra/release_notes.html
@@ -1,0 +1,25 @@
+{% extends 'terra/base.html' %}
+
+{% block title %}TERRA - Release Notes{% endblock %}
+
+{% block supplemental_css %}
+<style>
+    body {
+        padding-top: 6.5rem;
+
+}
+</style>
+{% endblock %}
+
+{% block body %}
+<h3>Release Notes</h3>
+<hr/>
+
+<h4>1.1.5</h4>
+<p><i>February 28, 2025</i></p>
+<ul>
+    <li>Updated Django to 4.2.19 to patch security issues.</li>
+    <li>Added release notes.</li>
+</ul>
+
+{% endblock %}

--- a/terra/views.py
+++ b/terra/views.py
@@ -5,6 +5,7 @@ from django.views.generic.list import ListView
 from django.views.generic import DetailView
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from django.contrib.auth.decorators import login_required
+from django.shortcuts import render
 
 from .models import TravelRequest, Unit, Employee, Fund, ActualExpense
 from .reports import (
@@ -45,6 +46,11 @@ def employee_type_list(request):
             },
         )
     )
+
+
+@login_required
+def release_notes(request):
+    return render(request, "terra/release_notes.html")
 
 
 class EmployeeDetailView(LoginRequiredMixin, UserPassesTestMixin, DetailView):


### PR DESCRIPTION
Implements [SYS-1751](https://uclalibrary.atlassian.net/browse/SYS-1751)

- Updated Django to 4.2.19 to patch security issues
- Bumped Helm chart version tag
- Added release note template, view, and URL

**Testing**
✅ All automated tests passed in local development environment

[SYS-1751]: https://uclalibrary.atlassian.net/browse/SYS-1751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ