### PR TITLE
SYS-2009: Update Django to 5.2.6 to patch security issues

### DIFF
--- a/charts/prod-terra-values.yaml
+++ b/charts/prod-terra-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/terra
-  tag: v1.1.6
+  tag: v1.1.7
   pullPolicy: Always
 
 nameOverride: ""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==5.2.1
+Django==5.2.6
 psycopg==3.2.9
 django-crispy-forms==2.1
 crispy-bootstrap5==2023.10

--- a/terra/templates/terra/release_notes.html
+++ b/terra/templates/terra/release_notes.html
@@ -15,6 +15,12 @@
 <h3>Release Notes</h3>
 <hr />
 
+<h4>1.1.7</h4>
+<p><i>September 18, 2025</i></p>
+<ul>
+    <li>Updated Django to 5.2.6 to patch security issues.</li>
+</ul>
+
 <h4>1.1.6</h4>
 <p><i>May 16, 2025</i></p>
 <ul>


### PR DESCRIPTION
Implements [SYS-2009](https://uclalibrary.atlassian.net/browse/SYS-2009)

### Acceptance criteria
- [X] Django is updated to the [latest version](https://docs.djangoproject.com/en/5.2/releases/) (5.2.6 as of September 2025)
- [X] Update release notes and version for deployment

### Description
Updating to Django 5.2.6 should resolve the two active dependabot alerts. All 81 tests should still pass after rebuilding the `django` container to apply the update.

[SYS-2009]: https://uclalibrary.atlassian.net/browse/SYS-2009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ